### PR TITLE
add role which updates nginx config for the blobs server

### DIFF
--- a/planetary-graphql.yml
+++ b/planetary-graphql.yml
@@ -27,5 +27,4 @@
   #  - node-js
   #  NOTE node-js is only needed first time we run this playbook
     - letsencrypt-nginx
-    - planetary-graphql-blobs
     - planetary-graphql

--- a/roles/letsencrypt-nginx/tasks/main.yml
+++ b/roles/letsencrypt-nginx/tasks/main.yml
@@ -63,8 +63,8 @@
               proxy_read_timeout 90s;
             }
 
-            # WARNING: changing the line below may affect ansible roles using it to append additional config below
-            # <!-- INSERT ADDITIONAL CONFIG BELOW -->
+            # NOTE - do not change line below, it is used by ansible to inset config
+            # <!-- ANSIBLE: INSERT AFTER -->
           }
   
   - name: Make Sure NGINX Service Is Running

--- a/roles/planetary-graphql/tasks/main.yml
+++ b/roles/planetary-graphql/tasks/main.yml
@@ -6,6 +6,13 @@
 # 2. assign a "reserved IP address" (static address)
 # 3. add the Droplet to /prod-inventory.yml
 
+- name: Setup blob server nginx config
+  ansible.builtin.import_tasks: tasks/nginx-blob-config.yml
+# - name: Test TCP connectivity
+#   become: true
+#   become_user: root
+#   import_tasks: 'tasks/nginx-blob-config.yml'
+
 - name: Clone planetary-graphql
   git:
     repo: https://github.com/planetary-social/planetary-graphql.git

--- a/roles/planetary-graphql/tasks/nginx-blob-config.yml
+++ b/roles/planetary-graphql/tasks/nginx-blob-config.yml
@@ -5,14 +5,14 @@
   ansible.builtin.blockinfile:
     path: /etc/nginx/conf.d/graphql.planetary.pub.conf
     marker: "# {mark} ANSIBLE MANAGED BLOCK FOR BLOB SERVER NGINX CONFIG"
-    insertafter: "# <!-- INSERT ADDITIONAL CONFIG BELOW -->"
+    insertafter: "# <!-- ANSIBLE: INSERT AFTER -->"
     block: |
         # map `/blob` to `/get` so the uri is /get/:blobId
         location /blob {
-          rewrite  ^  $request_uri;             # get original URI
-          rewrite  ^/blob(/.*)  /get$1  break;  # drop /blob, put /get
-          return 400;   # if the second rewrite won't match
-          proxy_pass    http://127.0.0.1:26835$uri;
+          rewrite    ^  $request_uri;              # get original URI
+          rewrite    ^/blob(/.*)  /get$1  break;   # drop /blob, put /get
+          return     400;                          # if the second rewrite won't match
+          proxy_pass http://127.0.0.1:26835$uri;
         }
 
 - name: Make Sure NGINX Service Is Running


### PR DESCRIPTION
This adds configuration to the domains nginx config file so that requests are passed along to the blob server.

In our case, a request looks like this:
```
https://graphql.planetary.pub/blob/:blobId
```

And is the converted to this for the blob server to handle:
```
http://127.0.0.1:26835/get/:blobId
```

Notes:
- I made the location /blob as it was a lot tidier than `https://graphql.planetary.pub:26835/get/:blobId`
