### PR TITLE
Make memory limit a dynamic variable

### DIFF
--- a/roles/ssb-server/templates/start-sbot
+++ b/roles/ssb-server/templates/start-sbot
@@ -1,2 +1,4 @@
-docker run -d --name sbot -v ~/ssb-pub-data/:/home/node/.ssb/ -p 8008:8008 --restart unless-stopped --memory 3948060160 planetary-social/ssb-pub
+TOTAL_MEMORY=$(free -b --si | awk '/Mem:/ { print $2 }')
+MEMORY_LIMIT=$(expr $TOTAL_MEMORY - 200000000) # total memory less 200mb
+docker run -d --name sbot -v ~/ssb-pub-data/:/home/node/.ssb/ -p 8008:8008 --restart unless-stopped --memory $MEMORY_LIMIT planetary-social/ssb-pub
 docker run -d --name healer -v /var/run/docker.sock:/tmp/docker.sock --restart unless-stopped ahdinosaur/healer


### PR DESCRIPTION
At the moment, the start_sbot script has a hard-coded memory limit.  Planetary may be hitting this limit and causing the ssb-server to stop or behave erratically.  This change sets the limit to a dynamic variable, based ont he total memory of the container minus 200mb.  It is modelled after the [create-sbot script in ahdinosaur's ssb-server repo](https://github.com/ahdinosaur/ssb-pub#step-3-run-the-container)