### PR TITLE
Update ansible scripts for proper serving of blobs

### DIFF
--- a/roles/planetary-graphql/templates/docker-compose.yml.tpl
+++ b/roles/planetary-graphql/templates/docker-compose.yml.tpl
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '2.2'
 services:
   graphql:
     image: {{ graphql_docker_image }}:{{ graphql_docker_tag }}
@@ -11,7 +11,8 @@ services:
       - ROOM_KEY={{ admin_room_key }}
       - MAGIC_TOKEN={{ magic_token }}
       - LOGGING=true
-      - BLOBS_URL=http://0.0.0.0:{{graphql_blobs_port }}
+      - BLOBS_URL=/blob/
+      - NODE_ENV=production
     ports:
       - "{{ graphql_port }}:4000" # the graphql endpoint
       - "0.0.0.0:{{ graphql_blobs_port }}:26835" # the blob server


### PR DESCRIPTION
This updates our nginx config, and the docker-compose for graphql, to serve blobs from the path `/blob`.  This follows the pattern for the other services and makes sure that the blobs actually show up.  This is the script that was used to deploy https://planetary.pro and get blobs working on that site.