### PR TITLE
Hardening role

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,6 +17,19 @@
     upgrade: dist
     update_cache: yes
 
+
+- name: Remove dependencies that are no longer required.
+  ansible.builtin.apt:
+    autoremove: yes
+
+
+- name: Update and upgrade all installed packages
+  become: true
+  apt:
+    upgrade: yes
+    update_cache: yes
+
+
 - name: Check if a reboot is required.
   ansible.builtin.stat:
     path: /var/run/reboot-required
@@ -27,7 +40,3 @@
 - name: Reboot the server (if required).
   ansible.builtin.reboot:
   when: reboot_required_file.stat.exists == true
-
-- name: Remove dependencies that are no longer required.
-  ansible.builtin.apt:
-    autoremove: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,10 +1,16 @@
 - name: Install aptitude using apt
-  apt: name=aptitude state=latest update_cache=no force_apt_get=no
+  apt:
+    name: aptitude
+    state: latest
+    update_cache: no
+    force_apt_get: no
+
 
 - name: Remove old Digital Ocean Repository
   file:
     path: /etc/apt/sources.list.d/droplet-agent.list
     state: absent
+
 
 - name: Perform a dist-upgrade.
   ansible.builtin.apt:
@@ -16,6 +22,7 @@
     path: /var/run/reboot-required
     get_md5: no
   register: reboot_required_file
+
 
 - name: Reboot the server (if required).
   ansible.builtin.reboot:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -23,6 +23,20 @@
     autoremove: yes
 
 
+- name: Install common packages
+  apt:
+    pkg:
+      - curl
+      - vim
+      - git
+      - ufw
+      - rsync
+      - jq
+      - tmux
+    state: latest
+    update_cache: true
+
+
 - name: Update and upgrade all installed packages
   become: true
   apt:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,21 +1,16 @@
 - name: Install aptitude using apt
-  apt:
+  ansible.builtin.apt:
     name: aptitude
     state: latest
     update_cache: no
     force_apt_get: no
 
 
-- name: Remove old Digital Ocean Repository
-  file:
-    path: /etc/apt/sources.list.d/droplet-agent.list
-    state: absent
-
-
 - name: Perform a dist-upgrade.
   ansible.builtin.apt:
     upgrade: dist
     update_cache: yes
+    cache_valid_time: 3600
 
 
 - name: Remove dependencies that are no longer required.
@@ -23,8 +18,27 @@
     autoremove: yes
 
 
+- name: "Disable Snapd Service"
+  ansible.builtin.service:
+    name: snapd
+    state: stopped
+    enabled: false
+
+
+- name: "Uninstall Snapd"
+  ansible.builtin.apt:
+    pkg: snapd
+    state: absent
+
+
+- name: "Remove Snapd directory"
+  ansible.builtin.file:
+    path: /root/snap
+    state: absent
+
+
 - name: Install common packages
-  apt:
+  ansible.builtin.apt:
     pkg:
       - curl
       - vim
@@ -33,15 +47,18 @@
       - rsync
       - jq
       - tmux
+      - mosh
     state: latest
     update_cache: true
+    cache_valid_time: 3600
 
 
 - name: Update and upgrade all installed packages
   become: true
-  apt:
+  ansible.builtin.apt:
     upgrade: yes
     update_cache: yes
+    cache_valid_time: 3600
 
 
 - name: Check if a reboot is required.

--- a/roles/digital-ocean/tasks/main.yml
+++ b/roles/digital-ocean/tasks/main.yml
@@ -1,18 +1,34 @@
 ---
 # Tasks that should be run on all Digital Ocean droplets
 
-- name: Add Digital Ocean Repo Key 
-  apt_key:
+- name: Remove old Digital Ocean Repository
+  become: true
+  ansibile.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/apt/sources.list.d/droplet-agent.list
+    - /etc/apt/sources.list.d/digitalocean-agent.list
+
+
+- name: Add Digital Ocean Repo Key
+  become: true
+  ansible.builtin.apt_key:
     url: https://repos.insights.digitalocean.com/sonar-agent.asc
     state: present
 
+
 - name: Add Digital Ocean Repository
-  apt_repository:
+  become: true
+  ansible.builtin.apt_repository:
     repo: deb https://repos.insights.digitalocean.com/apt/do-agent/ main main
     state: present
 
+
 - name: Install Metrics Agent
-  apt:
+  become: true
+  ansible.builtin.apt:
     name: do-agent
     state: present
     update_cache: yes
+    cache_valid_time: 3600

--- a/roles/digital-ocean/tasks/main.yml
+++ b/roles/digital-ocean/tasks/main.yml
@@ -16,8 +16,3 @@
     name: do-agent
     state: present
     update_cache: yes
-
-- name: Install Mosh shell
-  apt:
-    name: mosh
-    state: present

--- a/roles/harden/README.md
+++ b/roles/harden/README.md
@@ -1,0 +1,32 @@
+# Planetary Server Hardening Role
+
+This role is intended to be one of the first run when creating a new server, to do some basic security hardening.
+
+The primary goals of this role are to:
+- ensure software is up to date
+- restrict logins and avoid easy brute-forcing into the server
+- add firewalls to only broadcast from intentional ports
+
+## Ensuring software is up to date
+We set a dependency in this role for our common role, which mainly does a software update and installs some of our necessary programs.
+
+## Restricting logins
+This role sets that you must login with an ssh key, removing the ability to just use a username and password.
+
+In addition, it creates an admin user and removes the ability to login as root. The admin user is part of the sudo group, and so can perform higher-clearance tasks if needed, but from this point forward nothing should be done directly as root.
+
+**Note: after running this role, you will not be able to login as root. You will login as `{{admin_username}}@server_address`**
+
+## Add Firewalls
+
+We use [UFW](https://help.ubuntu.com/community/UFW), the default firewall configuration for ubuntu and set it as highly restricted by default. After this role runs, the only port enabled is the ssh port.
+
+The roles you run after this, if they are setting up an externally accessible service, should include a UFW task that enables the required ports.
+
+
+# Variables in this role
+| variable         | example                               | purpose                                          |
+|:-----------------|:--------------------------------------|--------------------------------------------------|
+| admin_username   | admin                                 | new sudo user all other roles will run under     |
+| admin_password   | $jajdjsla;1jedksla;j                  | an encrypted password string(e.g. via bcrypt)    |
+| admin_ssh_pubkey | /Home/cooldracula/.ssh/id_ed25519.pub | absolute path to pubkey, for logging in as admin |

--- a/roles/harden/defaults/main.yaml
+++ b/roles/harden/defaults/main.yaml
@@ -1,0 +1,3 @@
+admin_username: admin
+admin_password: "use bcrypt to set this as an encrypted password"
+admin_ssh_pubkey: /Home/coolperson/.ssh/id_ed25519.pub

--- a/roles/harden/meta/main.yaml
+++ b/roles/harden/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: common

--- a/roles/harden/tasks/main.yaml
+++ b/roles/harden/tasks/main.yaml
@@ -1,0 +1,65 @@
+---
+# tasks for hardening a server before further ansible work
+
+- name: Setup passwordless sudo
+  ansible.builtin.lineinfile:
+    path: /etc/sudoers
+    state: present
+    regex: '^%sudo'
+    line: '%sudo ALL=(ALL) NOPASSWD: ALL'
+    validate: '/usr/sbin/visudo -cf %s'
+
+
+- name: Create a new regular user with sudo privileges
+  ansible.builtin.user:
+    name: "{{ admin_username }}"
+    state: present
+    groups: sudo
+    append: true
+    password: "{{ admin_password }}"
+    shell: "/bin/bash"
+    create_home: true
+
+
+- name: Set authorized key for remote admin
+  ansible.posix.authorized_key:
+    user: "{{ admin_username }}"
+    state: present
+    key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/' + admin_ssh_key) }}"
+
+
+- name: Disable password login for everyone
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    state: present
+    regexp: '^#?PasswordAuthentication'
+    line: 'PasswordAuthentication no'
+    validate: "/usr/sbin/sshd -t -f %s"
+
+
+- name: Disable login for root
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    state: present
+    regexp: '^#?PermitRootLogin'
+    line: 'PermitRootLogin no'
+    validate: "/usr/sbin/sshd -t -f %s"
+
+
+- name: Restart sshd
+  ansible.builtin.systemd:
+    name: ssh
+    daemon_reload: true
+    state: restarted
+
+
+- name: UFW - Allow SSH connections
+  community.general.ufw:
+    rule: allow
+    name: OpenSSH
+
+
+- name: UFW - Enable and deny by default
+  community.general.ufw:
+    state: enabled
+    default: deny

--- a/roles/harden/tasks/main.yaml
+++ b/roles/harden/tasks/main.yaml
@@ -25,7 +25,8 @@
   ansible.posix.authorized_key:
     user: "{{ admin_username }}"
     state: present
-    key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/' + admin_ssh_key) }}"
+    key: "{{ lookup('file', admin_ssh_pubkey) }}"
+  register: admin_added
 
 
 - name: Disable password login for everyone


### PR DESCRIPTION
This adds a role to harden new servers, regardless of how they'll be used.  

It's general purpose security hardening, mostly enforcing the following:
- you must use an ssh key to ssh into a server
- you cannot login as root
- Firewall is on by default and, at the start, only allows ssh access

The biggest change to flow is not logging in as root.  Instead, an admin user is created, who is part of the sudoers group.  We then intentionally become root for tasks that call for it, but otherwise everything is done as an admin user. 

