### PR TITLE
Add certbot-cloudflare role

### DIFF
--- a/roles/certbot-cloudflare/README.md
+++ b/roles/certbot-cloudflare/README.md
@@ -1,0 +1,47 @@
+# Certbot and Cloudflare Role
+
+This role uses certbot, and the cloudflare api, to setup ssl certificates for a
+given server.
+
+It will only create the certificates and put them in the right place. You can
+then reference them in something like the nginx-single-host role, where the
+configuration the role copies onto the server references the certificates made here.
+
+This role requires a cloudflare account, with the domains held by cloudflare.  You 
+can sign up for a free plan here: https://www.cloudflare.com/. It also requires creating
+an [Edit Zone DNS token in your cloudflare dashboard](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/).
+
+
+**Note: when you setup a domain on cloudflare, it acts as a proxy by default.
+This means it will both try to set up the certs for you and restrict ports
+available on your server. We don't want cloudflare to do either. After you setup
+the domain, ensure that "proxied" is toggled to off, and it says dns only.**
+
+## Certs Renewal
+
+This role utilizes certbot's own system for renewals.  Since we are issuing certs through 
+the builtin plugin, we also benefit from automated renewals.  
+
+The renewals are handled via systemd and a certbot timer.  On the server, you can see the list of systemd timers with:
+
+``` sh
+systemctl list-timers
+```
+
+and see the last time the renewal job was run with:
+
+``` sh
+systemctl status certbot
+```
+
+# Variables in this Role
+
+| variable             | example              | purpose                                                                    |
+|:---------------------|:---------------------|:---------------------------------------------------------------------------|
+| admin_username       | admin                | who you log into the server as, instead of root.                           |
+| domain               | ansible.fun          | fqdn of host server. should be set in inventory                            |
+| wildcard_needed      | true                 | whether role should get certs for *.domain too.                            |
+| cloudflare_api_token | someApiString        | the zoned token created in cloudflare.                                     |
+| cert_email           | ops@planetary.social | email used when assigning cert, for receiving notices (renewal,issues,etc) |
+
+

--- a/roles/certbot-cloudflare/defaults/main.yaml
+++ b/roles/certbot-cloudflare/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+wildcard_needed: false

--- a/roles/certbot-cloudflare/tasks/main.yml
+++ b/roles/certbot-cloudflare/tasks/main.yml
@@ -1,0 +1,59 @@
+# Setup certificates for https using certbot and a cloudflare dns plugin
+---
+- name: Install certbot and plugins
+  become: true
+  ansible.builtin.package:
+    pkg:
+      - certbot
+      - python3-certbot-nginx
+      - python3-certbot-dns-cloudflare
+    state: latest
+    update_cache: yes
+    cache_valid_time: 3600
+
+
+- name: Create config directory
+  ansible.builtin.file:
+    path: /home/{{ admin_username }}/.config/certbot
+    state: directory
+    mode: 0755
+
+
+- name: Upload cloudflare credentials
+  ansible.builtin.template:
+    src: cloudflare.ini.tpl
+    dest: /home/{{ admin_username }}/.config/certbot/cloudflare.ini
+    mode: 0600
+
+
+- set_fact:
+    domains_list: "{{ domain + ',' + '*.' + domain if wildcard_needed == true else domain }}"
+
+
+- name: Add certificates for host
+  become: true
+  ansible.builtin.shell:
+    cmd: |
+      certbot certonly \
+      --non-interactive \
+      --agree-tos  \
+      --dns-cloudflare \
+      --dns-cloudflare-credentials /home/{{ admin_username }}/.config/certbot/cloudflare.ini \
+      --email {{ cert_email }} \
+      -d {{ domains_list }}
+
+
+- name: Get latest options ssl conf
+  become: true
+  ansible.builtin.uri:
+    url: 'https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf'
+    method: GET
+    dest: /etc/letsencrypt/options-ssl-nginx.conf
+
+
+- name: Get latest ssl-dhparams
+  become: true
+  ansible.builtin.uri:
+    url: 'https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem'
+    method: GET
+    dest: /etc/letsencrypt/ssl-dhparams.pem

--- a/roles/certbot-cloudflare/templates/cloudflare.ini.tpl
+++ b/roles/certbot-cloudflare/templates/cloudflare.ini.tpl
@@ -1,0 +1,1 @@
+dns_cloudflare_api_token={{ cloudflare_api_token }}


### PR DESCRIPTION
This role allows you to set up the certificates, including wildcard domain certificates, for a server and have them automatically renew, by utilizing the cloudflare api.

I detail it further in the README included in this PR