### PR TITLE
Updated nginx role

### DIFF
--- a/roles/nginx-single-host/README.md
+++ b/roles/nginx-single-host/README.md
@@ -1,0 +1,29 @@
+# Nginx Single Host Role
+
+
+This role sets up nginx, and the proper config, for a planetary room instance
+where all the services are on a single host and share a domain. For example: the
+host `planet.fun`` has
+[go-ssb-room](https://github.com/planetary-social/go-ssb-room),
+[planetary-graphql](https://github.com/planetary-social/planetary-graphql), and
+[rooms-frontend](https://github.com/planetary-social/rooms-frontend) all running on it and they are accessible via `planet.name/login`,
+`planet.name/graphql`, and `planet.name/` respectively.
+
+This role depends on certbot-cloudflare to be run first, so that the
+certificates referenced in the site config we copy over are already available on
+the server.
+
+Along with setting up the proxy, this role also expands the default config to
+allow for better websocket connections and to gzip all text content passed
+along, to help speed up the sites.
+
+## The etc/hosts adjustments 
+This role assumes its being run on one of our digital ocean droplets.  Our current pattern is to name the droplet after the url,
+and then digital ocean sets this as the hostname in /etc/hosts.  This causes a name clash within our services cos of fun containerization [reasons](https://github.com/planetary-social/infrastructure/wiki/Planetary.name-update-report#what-is-happening).   The tasks around
+/etc/hosts are just to remove this clash, and convert the hostname from `planet.fun` to `planetfun`
+
+# Variables in this role
+
+| variable | example    | purpose                                               |
+| domain   | planet.fun | the fqdn of the host, should be set in your inventory |
+

--- a/roles/nginx-single-host/files/nginx.conf
+++ b/roles/nginx-single-host/files/nginx.conf
@@ -1,0 +1,84 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+worker_connections 768;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_comp_level 6;
+	gzip_buffers 16 8k;
+	gzip_http_version 1.1;
+	gzip_min_length 256;
+	gzip_types
+		application/atom+xml
+		application/geo+json
+		application/javascript
+		application/x-javascript
+		application/json
+		application/ld+json
+		application/manifest+json
+		application/rdf+xml
+		application/rss+xml
+		application/xhtml+xml
+		application/xml
+		font/eot
+		font/otf
+		font/ttf
+		image/svg+xml
+		text/css
+		text/javascript
+		text/plain
+		text/xml;
+
+
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}

--- a/roles/nginx-single-host/meta/main.yaml
+++ b/roles/nginx-single-host/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - certbot-cloudflare

--- a/roles/nginx-single-host/tasks/main.yml
+++ b/roles/nginx-single-host/tasks/main.yml
@@ -1,25 +1,37 @@
 ---
-# This role sets up nginx, and the proper config, for
-# a planetary room instance where all the services are on a
-# single host and share a domain. For example: the host planet.fun
-# has go-ssb-room, planetary-graphql, and rooms-frontend all running
-# on it and they are accessible via planet.name/login, planet.name, and
-# planet.name/graphql respectively
 
 - name: Update and upgrade apt packages
-  apt:
+  become: true
+  ansible.builtin.apt:
     upgrade: yes
     update_cache: yes
     cache_valid_time: 86400
 
 
-- name: Install nginx and certbot
-  apt:
+- name: Install nginx
+  become: true
+  ansible.builtin.apt:
     pkg:
       - nginx
-      - certbot
-      - python3-certbot-nginx
     state: latest
+
+
+- name: etc/hosts - Prevent nameclashes with hostname
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    state: present
+    regex: "^127.0.1.1 {{ domain }}.*$"
+    line: "127.0.1.1 {{ domain | replace('.','') }}"
+
+
+- name: etc/hosts template - Prevent nameclashes with hostname
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/cloud/templates/hosts.debian.tmpl
+    state: present
+    regex: "^127.0.1.1 \\{\\{fqdn\\}\\}.*$"
+    line: "127.0.1.1 {{ domain | replace('.','') }}"
 
 
 - name: Confirm nginx conf folder exists
@@ -27,8 +39,18 @@
     path: "/etc/nginx/conf.d"
   register: conf_d
 
-# This sets the connection_upgrade var used in our site config
+
+- name: Add our custom config with extended gzip settings
+  become: true
+  ansible.builtin.copy:
+    src: nginx.conf
+    dest: "/etc/nginx/conf.d/nginx.conf"
+  when: conf_d.stat.exists
+
+
+  # This sets the connection_upgrade var used in our site config
 - name: Copy websocket_upgrade.conf to conf.d
+  become: true
   ansible.builtin.copy:
     src: websocket_upgrade.conf
     dest: "/etc/nginx/conf.d/websocket_upgrade.conf"
@@ -36,49 +58,42 @@
 
 
 - name: Build and copy over site config
+  become: true
   ansible.builtin.template:
     src: site.conf.tpl
-    dest: "/etc/nginx/sites-available/{{ inventory_hostname }}"
+    dest: "/etc/nginx/sites-available/{{ domain }}"
 
 
-- name: remove default site config
-  file:
+- name: Remove default site config from sites-enabled
+  become: true
+  ansible.builtin.file:
     path: /etc/nginx/sites-enabled/default
     state: absent
 
 
-- name: symlink site config to sites-enabled
-  file:
-    src: "/etc/nginx/sites-available/{{ inventory_hostname }}"
-    dest: "/etc/nginx/sites-enabled/{{ inventory_hostname }}"
+- name: Symlink site config to sites-enabled
+  become: true
+  ansible.builtin.file:
+    src: "/etc/nginx/sites-available/{{ domain }}"
+    dest: "/etc/nginx/sites-enabled/{{ domain }}"
     state: link
 
 
+- name: UFW - Allow http/https connections
+  become: true
+  community.general.ufw:
+    rule: allow
+    name: "Nginx Full"
+
+
 - name: Ensure config is valid
+  become: true
   ansible.builtin.command: nginx -t
   changed_when: false
-  notify: restart nginx
 
 
-- name: "Print out certbot instructions"
-  ansible.builtin.debug:
-    msg: "Successfully set up the host!  There are some manual steps to be done on the server. SSH in and read /root/success.txt"
-
-- name: success to file
-  ansible.builtin.copy:
-    dest: /root/success.txt
-    content: |
-      Congratulations! You've got everything set up and are almost done.
-      The only thing left is to run certbot so your site is actually up.
-      This is best done manually on the host server.
-      First, ensure you have your DNS set up with following records:
-        A Record: {{inventory_hostname}}-> pointing to the IP of yr host\n
-        A Record: *.{{inventory_hostname}}->pointing to same ip "\n
-      Then, after ssh'ing into the host, run this command:\n
-          certbot certonly --manual \
-          --server https://acme-v02.api.letsencrypt.org/directory \
-          --preferred-challenges dns-01 \
-          -d '{{ inventory_hostname }}' -d '*.{{ inventory_hostname }}'\
-      After htis is done run:
-        sudo certbot (and follow its steps)
-        sudo systemctl restart nginx
+- name: Restart nginx
+  become: true
+  ansible.builtin.service:
+    name: nginx
+    state: restarted

--- a/roles/nginx-single-host/templates/site.conf.tpl
+++ b/roles/nginx-single-host/templates/site.conf.tpl
@@ -19,115 +19,90 @@ upstream blob {
   server localhost:{{ graphql_blob_port }};
 }
 
+#Our caching proxy setup
+proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=coolcache:500m max_size=1g;
+proxy_cache_key "$scheme$request_method$host$request_uri$is_args$args";
+
 server {
     server_name {{ inventory_hostname }};
-
-    ## There is a lot of redundancy in the props of these location
-    ## blocks at this early stage of the config. It is mostly to ensure it
-    ## all works.  I wanted to be as explicit in the routes as possible,
-    ## though some of these can likely be removed through clever regex.
-
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
 
    ## Route the root path, and all profile paths, to our frontend server
     location  = / {
+       expires 60m;
+       add_header X-Proxy-Cache $upstream_cache_status;
+       proxy_cache coolcache;
+       proxy_cache_bypass $http_cache_control;
        proxy_pass http://frontend/;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
        index  index.html index.htm;
        include  /etc/nginx/mime.types;
        try_files $uri $uri/ /index.html;
     }
 
+
     location ~ /(profile/.*) {
        proxy_pass http://frontend/$1;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
+       index  index.html index.htm;
+       include  /etc/nginx/mime.types;
+       try_files $uri $uri/ /index.html;
+    }
+
+    location ~ /(follow/.*) {
+       add_header X-Proxy-Cache $upstream_cache_status;
+       proxy_pass http://frontend/$1;
        index  index.html index.htm;
        include  /etc/nginx/mime.types;
        try_files $uri $uri/ /index.html;
     }
 
     location  = /index.html {
+       expires 60m;
+       add_header X-Proxy-Cache $upstream_cache_status;
+       proxy_cache coolcache;
+       proxy_cache_bypass $http_cache_control;
        proxy_pass http://frontend/;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
     }
 
 
     ## Route the admin styling to the room server
     location ~ /assets/((style|fixfouc).css) {
        proxy_pass http://room/assets/$1;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
     }
 
 
     ## Anything else in /assets should come from frontend
     location ~ /assets/(.*) {
+       expires 60m;
+       proxy_cache coolcache;
+       proxy_cache_bypass $http_cache_control;
        proxy_pass http://frontend/assets/$1;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
     }
 
     ## all graphql paths go to the graphql server
     location  /graphql/ {
        proxy_pass http://graphql/graphql/;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
+       proxy_cache coolcache;
+       proxy_cache_bypass $http_cache_control;
     }
 
-    ## Any blob request redirects to /blob/get/$request (this is due to how ssb-blob-server is set up)
+    ## all graphql paths go to the graphql server
     location  ~ /blob/(.*) {
+       expires 60m;
+       proxy_cache coolcache;
+       proxy_cache_bypass $http_cache_control;
+       add_header X-Proxy-Cache $upstream_cache_status;
        proxy_pass http://blob/get/$1;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
     }
 
     ## For any other path not yet specified, use the room server.
     location  / {
        proxy_pass http://room;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
     }
 
     ## TODO: The room server router is set up with bare paths (e.g. /login instead of /login)
@@ -136,23 +111,32 @@ server {
 
     location  ~ /(login|logout)/ {
        proxy_pass http://room/$1;
-       proxy_set_header Host $host;
-       proxy_set_header X-Forwarded-Host $host;
-       proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
-       proxy_set_header X-Forwarded-Proto $scheme;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection $connection_upgrade;
+    }
+
+    location  /admin/dashboard/ {
+       proxy_pass http://room/admin/dashboard;
     }
 
     # TODO: https://blog.tarq.io/nginx-catch-all-error-pages/
+
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 }
 
 ## this server uses the (same) wildcard cert as the one above but uses a regular expression on the hostname
 ## which extracts the first subdomain which holds the alias and forwards that to the prox_pass server
-## This isn't quite working yet, mostly cos we need to know the right place to redirect.
+
 server {
     server_name "~^(?<profile>\w+)\.{{ inventory_hostname|replace(".","\.") }}$";
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
 
     location = / {
@@ -162,7 +146,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         # "rewrite" requests with subdomains to the non-wildcard url for alias resolving
         # $is_args$args pass on ?encoding=json if present
-        proxy_pass http://frontend/profile/$profile$is_args$args;
+        return 302 http://{{ inventory_hostname }}/profile/alias/$profile$is_args$args;
     }
 
     location / {
@@ -170,6 +154,23 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $remote_addr:$remote_port;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://frontend/;
+        proxy_pass http://room;
     }
+}
+
+server {
+    if ($host = {{ inventory_hostname }}) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    if ($host ~ {{ inventory_hostname }}$) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    listen 80;
+    listen [::]:80 default_server;
+    server_name {{ inventory_hostname }};
+    return 404; # managed by Certbot
 }

--- a/roles/nginx-single-host/templates/site.conf.tpl
+++ b/roles/nginx-single-host/templates/site.conf.tpl
@@ -53,6 +53,13 @@ server {
        try_files $uri $uri/ /index.html;
     }
 
+    location ~ /(thread/.*) {
+       proxy_pass http://frontend/$1;
+       index  index.html index.htm;
+       include  /etc/nginx/mime.types;
+       try_files $uri $uri/ /index.html;
+    }
+
     location ~ /(follow/.*) {
        add_header X-Proxy-Cache $upstream_cache_status;
        proxy_pass http://frontend/$1;

--- a/single-host-example-inventory.yaml
+++ b/single-host-example-inventory.yaml
@@ -1,24 +1,10 @@
 # An example inventory for use with the single-host playbook
-lab:
-  hosts:
-    ansible.fun:
+# We use a var file in vars/main.yaml, that is edited for these particular servers.
+staging:
   vars:
-    ansible_user: root
-    cert_email: ops@planetary.social
-    frontend_port: 3000
-    frontend_docker_image: zachboyofdestiny/rooms-frontend
-    frontend_docker_tag: 1.2
-    room_port: 5000
-    room_docker_image: zachboyofdestiny/go-ssb-room
-    room_docker_tag: 1.1
-    room_aliases_as_subdomains: false
-    room_add_admin: true
-    room_admin_ssb_key: "yrssbkey.ed25519"
-    room_admin_password: admin
-    graphql_docker_image: zachboyofdestiny/planetary-graphql
-    graphql_docker_tag: dev2
-    room_bypass_invites_token: someexampleinvitetoken
-    graphql_port: 4000
-    graphql_blobs_port: 26835
-    graphql_password: admin
-    magic_token: 3vdWyLACyrKtzdveenWq9wbbPXh1Aq-Ds7VcUMX6kE27mW9K4k4a3tPFjE_Cjz_9rYA=
+    wildcard_needed: true
+  hosts:
+    cooltesting.space:
+      domain: "cooltesting.space"
+    ansible.fun:
+      domain: "ansible.fun"

--- a/single-host-playbook.yaml
+++ b/single-host-playbook.yaml
@@ -1,11 +1,14 @@
 - name:  Creating a room instance on a single host and domain.
-  hosts: lab
+  hosts: staging
+  vars:
+    ansible_user: admin
+  vars_file:
+    - vars/main.yaml
   roles:
-    - common
-    - debugging
     - digital-ocean
     - docker
     - rooms-frontend
     - go-ssb-room
     - planetary-graphql
+    - certbot-cloudflare
     - nginx-single-host

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,0 +1,40 @@
+# Basic Server setup #
+#####################
+admin_username: admin # who we will login as instead of root
+admin_password: $some$encrypted@string$via$brcypt # an encrypted string, generated locally.
+admin_ssh_pubkey: /Home/cooldracula/.ssh/id_ed25519.pub
+
+
+#   Rooms Frontend   #
+#####################
+frontend_docker_image: cooldracula/rooms-frontend
+frontend_docker_tag: stable
+frontend_port: 3000
+
+
+#    Go-ssb-room     #
+#####################
+room_docker_image: cooldracula/go-ssb-room
+room_docker_tag: stable
+room_port: 5000
+room_aliases_as_subdomains: false
+room_add_admin: true
+room_admin_ssb_key: "@someSSBKey=ed25519"
+room_admin_password: somepassword
+
+
+# planetary-graphql  #
+#####################
+graphql_docker_image: cooldracula/planetary-graphql
+graphql_docker_tag: stable
+graphql_port: 4000
+graphql_blob_port: 26835
+room_bypass_invites_token: aGeneratedHashjajdj23135311
+graphql_password: somepassword
+magic_token: aGeneratedHashjajdj23135311
+
+
+# certbot-cloudflare-dns #
+#########################
+cert_email: ops@planetary.social
+cloudflare_api_token: tokenGeneratedViaCloudflareDashboard


### PR DESCRIPTION


This PR updates our nginx-single-host role to both take advantage of our cloudflare-certbot role and to improve our standard nginx config for the planetary-server single host pattern(e.g. what we use for planetary.name).  This role is expanded in a README included in this PR.
