### PR TITLE
add delete-old-blobs cronjob

### DIFF
--- a/delete-old-blobs.yml
+++ b/delete-old-blobs.yml
@@ -1,0 +1,26 @@
+---
+# Adds cronjob that deletes blobs that have not been accessed in 120 days or more.
+# Usage: ansible-playbook -i {inventory} delete-old-blobs.yml
+- name: Setup "Delete Old Blobs" cronjob
+  hosts: pubs
+  tasks:
+    - name: Copy delete-old-blobs script
+      ansible.builtin.copy:
+       src: files/scripts/delete-old-blobs.sh
+       dest: /usr/local/bin/delete-old-blobs.sh
+       mode: '0644'
+
+
+    - name: Create delete-old-blobs.log
+      ansible.builtin.file:
+        path: /var/log/delete-old-blobs.log
+        state: touch
+        mode: '0600'
+
+
+    - name: Set up cronjob
+      ansible.builtin.cron:
+        name: "delete old blobs"
+        minute: "1"
+        hour: "0"
+        job: "delete-old-blobs.sh >> /var/log/delete-old-blobs.log"

--- a/files/scripts/delete-old-blobs.sh
+++ b/files/scripts/delete-old-blobs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+RECLAIMED=$(find ssb-pub-data/blobs -atime +120 -printf "%k\n" | awk 'BEGIN{total=0} {total=total+$1} END{print total}')
+find ssb-pub-data/blobs -atime +120 -exec rm {} \;
+echo $(date -I) $RECLAIMED"MiB reclaimed"


### PR DESCRIPTION
This pr adds a playbook, intended for our ssb pubs, to setup a cronjob for deleting any blob not accessed in at least 120 days.  It is in response to [infrastructure ticket #49](https://github.com/planetary-social/infrastructure/issues/49).

The job is set to run daily at a minute past midnight, will delete the blobs, and then output the total reclaimed space to /var/log/delete-old-blobs.log

I've run the playbook successfully on the pubs already, and now wanna save it for our records.