### PR TITLE
Add rsslay role and example inventory/playbook

### DIFF
--- a/roles/rsslay/README.md
+++ b/roles/rsslay/README.md
@@ -1,0 +1,15 @@
+# RSSLay role
+
+This role sets up an rsslay instance on a target server set up with an nginx reverse proxy.  
+
+We use docker-compose for our deployment, with an image generated automatically from https://github.com/planetary-social/rsslay
+
+Along with setting up the nginx configuration for the site, this role also sets up a scheduled task that checks our registry
+for a new version of our stable image, restarting the service with the updated image if necessary.
+
+## Variables
+
+| variable | example    | purpose                                               |
+| rsslay_domain   | rsslay_planet.fun | the fqdn of the service |
+| rsslay_port   | 9018 | what port to map on the host to the container. |
+| rsslay_secret_string   | oohchacha | any string, used for generating id's by rsslay |

--- a/roles/rsslay/files/rsslay-image-update.sh
+++ b/roles/rsslay/files/rsslay-image-update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+currentHash=$(docker inspect cooldracula/rsslay:stable --format "{{ .Id }}")
+
+docker-compose pull -q
+
+newHash=$(docker inspect cooldracula/rsslay:stable --format "{{ .Id }}")
+
+if [[ "$currentHash" != "$newHash" ]]; then
+        docker-compose up -d
+        echo "updated service to image id $newHash"
+fi

--- a/roles/rsslay/files/rsslay-image-update.timer
+++ b/roles/rsslay/files/rsslay-image-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Runs rsslay-image-update every 3 minutes
+Requires=rsslay-image-update.service
+
+[Timer]
+Unit=rsslay-image-update.service
+OnUnitActiveSec=3m
+
+[Install]
+WantedBy=timers.target

--- a/roles/rsslay/tasks/main.yml
+++ b/roles/rsslay/tasks/main.yml
@@ -1,0 +1,121 @@
+---
+- name: Ensure rsslay dir exists
+  ansible.builtin.file:
+    path: /home/{{ admin_username }}/rsslay
+    state: directory
+    mode: '0755'
+
+- name: Copy docker-compose.yml to rsslay dir
+  ansible.builtin.template:
+    src: docker-compose.yml.tpl
+    dest: /home/{{ admin_username }}/rsslay/docker-compose.yml
+    mode: 0644
+
+
+- name: Start up rsslay
+  community.docker.docker_compose:
+    project_src: /home/{{  admin_username }}/rsslay
+    build: false
+    restarted: true
+  register: output
+
+
+- ansible.builtin.debug:
+    var: output
+
+
+- name: Set nginx config for all services
+  become: true
+  ansible.builtin.template:
+    src: nginx.conf.tpl
+    dest: /etc/nginx/sites-available/{{ rsslay_domain }}
+    mode: 0644
+
+
+- name: Symlink site config to sites-enabled
+  become: true
+  ansible.builtin.file:
+    src: "/etc/nginx/sites-available/{{ rsslay_domain }}"
+    dest: "/etc/nginx/sites-enabled/{{ rsslay_domain }}"
+    state: link
+
+
+- name: UFW - Allow http/https connections
+  become: true
+  community.general.ufw:
+    rule: allow
+    name: "Nginx Full"
+
+
+- name: UFW - Allow tcp connections for websockets
+  become: true
+  community.general.ufw:
+    rule: allow
+    port: 80
+    proto: tcp
+
+
+- name: Ensure config is valid
+  become: true
+  ansible.builtin.command: nginx -t
+  changed_when: false
+
+
+- name: Restart nginx
+  become: true
+  ansible.builtin.service:
+    name: nginx
+    state: restarted
+
+- name: Copy systemd service for rsslay image update
+  ansible.builtin.template:
+    src: rsslay-image-update.service.tpl
+    dest: /home/{{ admin_username }}/rsslay/rsslay-image-update.service
+    mode: 0644
+
+
+- name: Copy systemd timer for rsslay image update
+  ansible.builtin.copy:
+    src: rsslay-image-update.timer
+    dest: /home/{{ admin_username }}/rsslay/rsslay-image-update.timer
+    mode: 0644
+
+
+- name: Copy systemd shell script for rsslay image update
+  ansible.builtin.copy:
+    src: rsslay-image-update.sh
+    dest: /home/{{ admin_username }}/rsslay/rsslay-image-update.sh
+    mode: 0755
+
+
+- name: Symlink rsslay image update files to correct locations
+  become: true
+  ansible.builtin.file:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    state: link
+  loop:
+    - src: /home/{{ admin_username }}//rsslay/rsslay-image-update.service
+      dest: /etc/systemd/system/rsslay-image-update.service
+    - src: /home/{{ admin_username }}//rsslay/rsslay-image-update.timer
+      dest: /etc/systemd/system/rsslay-image-update.timer
+    - src: /home/{{ admin_username }}/rsslay/rsslay-image-update.sh
+      dest: /usr/local/bin/rsslay-image-update.sh
+
+
+- name: Enable image update service and timer
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: true
+  loop:
+    - rsslay-image-update.service
+    - rsslay-image-update.timer
+
+
+- name: Start image update service
+  become: true
+  ansible.builtin.systemd:
+    name: rsslay-image-update
+    state: started
+    daemon_reload: true

--- a/roles/rsslay/templates/docker-compose.yml.tpl
+++ b/roles/rsslay/templates/docker-compose.yml.tpl
@@ -1,0 +1,14 @@
+---
+version: '3'
+services:
+  rsslay:
+    image: cooldracula/rsslay:stable
+    container_name: rsslay
+    volumes:
+          - ./db:/db
+    ports:
+      - "0.0.0.0:{{ rsslay_port }}:8080"
+    environment:
+      - "SECRET={{ rsslay_secret_string }}"
+      - "DB_DIR=/db/rsslay.sqlite"
+    restart: always

--- a/roles/rsslay/templates/nginx.conf.tpl
+++ b/roles/rsslay/templates/nginx.conf.tpl
@@ -1,0 +1,39 @@
+server {
+        server_name {{ rsslay_domain }};
+
+
+        location / {
+                proxy_pass         http://127.0.0.1:{{ rsslay_port }}/;
+                proxy_redirect     off;
+
+                proxy_set_header   Host             $host;
+                proxy_set_header   X-Real-IP        $remote_addr;
+                proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+                proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 300s;
+                proxy_send_timeout 300s;
+                send_timeout 300s;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+        }
+
+
+
+        listen 443 ssl; # managed by Certbot
+                ssl_certificate /etc/letsencrypt/live/{{ rsslay_domain }}/fullchain.pem; # managed by Certbot
+                ssl_certificate_key /etc/letsencrypt/live/{{ rsslay_domain }}/privkey.pem; # managed by Certbot
+                include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+                ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+server {
+        if ($host = {{ rsslay_domain }}) {
+                return 301 https://$host$request_uri;
+        }
+
+        server_name {{ rsslay_domain }};
+        listen 80;
+        return 404; # managed by Certbot
+}

--- a/roles/rsslay/templates/rsslay-image-update.service.tpl
+++ b/roles/rsslay/templates/rsslay-image-update.service.tpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run rsslay-image-update: check for new image, restarting service if found.
+Wants=rsslay-image-update.timer
+
+[Service]
+ExecStart=/usr/local/bin/rsslay-image-update.sh
+WorkingDirectory=/home/{{ admin_username }}/rsslay
+
+[Install]
+WantedBy=multi-user.target

--- a/rsslay-example-inventory.yml
+++ b/rsslay-example-inventory.yml
@@ -1,0 +1,12 @@
+all:
+  vars:
+    cert_email: ops@planetary.social
+    cloudflare_api_token: apitoken_generated_by_cloudflare
+    admin_username: admin
+  hosts:
+    ansible.fun:
+      domains:
+        - rsslay.ansible.fun
+      rsslay_domain: rsslay.ansible.fun
+      rsslay_port: 9018
+      rsslay_secret_string: "ooohsecret"

--- a/rsslay-playbook.yml
+++ b/rsslay-playbook.yml
@@ -1,0 +1,11 @@
+- name: Create an rsslay instance on a target server
+  hosts: all
+  vars:
+    ansible_user: admin
+    admin_username: admin
+  roles:
+    - digital-ocean
+    - docker
+    - certbot-cloudflare
+    - nginx
+    - rsslay


### PR DESCRIPTION
This adds a role for creating an rsslay service on a ready planetary server. It includes the role, an example playbook, and an example inventory.

The role follows the pattern of adding a directory on the server named after the service, that holds a docker-compose file that is used to bring it up.  This file uses an image generated from our [rsslay repo](https://github.com/planetary-social/rsslay).    This repo has a workflow in place to create new images for every push to the main branch, and a new image tagged `stable` anytime we push a tag following a simple yyyy-mm-dd pattern.  

This role includes a systemd service that polls the container registry to see if there's a new version of the stable tag and if so restarts the service to use this updated image.  In this way, we can make sure our server is using the latest, stable version of the code without having to manually update it, and instead just push new tags to github.

This PR works as a proof of concept, having been used to bring up https://rsslay.ansible.fun.  However, it is using an image stored at the cooldracula docker registry.  We are also creating and pushing images to ghcr.io/planetary-social/rsslay, but these images are currently set to private.  When they are public, I can adjust this role to use images from that registry instead.   