### PR TITLE
Add node exporter role

### DIFF
--- a/node-exporter-playbook.yaml
+++ b/node-exporter-playbook.yaml
@@ -1,6 +1,6 @@
-- name: Create an rsslay instance on a target server
+- name: install node exporter service on target hosts
   hosts: all
   vars:
-    node_exporter_versin: 1.6.0
+    node_exporter_version: 1.6.0
   roles:
     - node-exporter

--- a/node-exporter-playbook.yaml
+++ b/node-exporter-playbook.yaml
@@ -1,0 +1,6 @@
+- name: Create an rsslay instance on a target server
+  hosts: all
+  vars:
+    node_exporter_versin: 1.6.0
+  roles:
+    - node-exporter

--- a/roles/node-exporter/README.md
+++ b/roles/node-exporter/README.md
@@ -1,0 +1,16 @@
+# Node Exporter role
+
+Installs [the node_exporter from
+prometheus](https://github.com/prometheus/node_exporter) onto the target host at
+the default port 9100. It assumes the target is an ubuntu service, with systemd
+and UFW for a firewall. The role uses systemd to ensure node-exporter stays
+running and extends the UFW rules to allow traffic on port 9100.
+
+# Variables
+
+| variable              | example     | purpose                                            |
+|:----------------------|:------------|:---------------------------------------------------|
+| node_exporter_version | 1.6.0       | version of node_exporter to use, defaults to 1.6.0 |
+| home_dir              | /home/admin | homdir of target, where files will be installed    |
+
+

--- a/roles/node-exporter/defaults/main.yaml
+++ b/roles/node-exporter/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+node_exporter_version: "1.6.0"

--- a/roles/node-exporter/files/node-exporter.service
+++ b/roles/node-exporter/files/node-exporter.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = Node Exporter: prometheus exporter for machine metrics
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/node_exporter
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/roles/node-exporter/tasks/main.yml
+++ b/roles/node-exporter/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+- name: Ensure node-exporter dir exists
+  ansible.builtin.file:
+    path: /{{ home_dir }}/node-exporter
+    state: directory
+    mode: '0755'
+
+
+- name: Download and unarchive node-exporter tarball
+  ansible.builtin.unarchive:
+    src: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz
+    dest: /{{ home_dir }}/node-exporter
+    remote_src: yes
+
+
+- name: Symlink node-exporter binary to /usr/local/bin
+  become: true
+  ansible.builtin.file:
+    src: /{{ home_dir }}/node-exporter/node_exporter-{{ node_exporter_version }}.linux-amd64/node_exporter
+    dest: /usr/local/bin/node_exporter
+    state: link
+
+
+- name: Copy systemd unit file
+  ansible.builtin.copy:
+    src: node-exporter.service
+    dest: /{{ home_dir }}/node-exporter/node-exporter.service
+    mode: 0644
+
+
+- name: Symlink service file to systemd service dir
+  become: true
+  ansible.builtin.file:
+    src: /{{ home_dir }}/node-exporter/node-exporter.service
+    dest: /etc/systemd/system/node-exporter.service
+    state: link
+
+
+- name: Enable node-exporter service
+  become: true
+  ansible.builtin.systemd:
+    name: node-exporter.service
+    enabled: true
+
+
+- name: Start node-exporter service
+  become: true
+  ansible.builtin.systemd:
+    name: node-exporter
+    state: started
+    daemon_reload: true
+
+
+- name: UFW - Allow tcp connection for node-exporter port
+  become: true
+  community.general.ufw:
+    rule: allow
+    port: 9100
+    proto: tcp


### PR DESCRIPTION
This adds a role and example playbook for installing the prometheus node_exporter to target hosts. 