### PR TITLE
Fix websocket-related headers not being passed to notification service

### DIFF
--- a/roles/nos-notification-service/templates/nginx.conf.tpl
+++ b/roles/nos-notification-service/templates/nginx.conf.tpl
@@ -6,6 +6,9 @@ server {
                 proxy_pass         http://127.0.0.1:{{ notifications_nostr_listen_address }}/;
                 proxy_redirect     off;
 
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "Upgrade";
+
                 proxy_set_header   Host             $host;
                 proxy_set_header   X-Real-IP        $remote_addr;
                 proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;


### PR DESCRIPTION
I believe we need those headers to get the websockets working.

http://nginx.org/en/docs/http/websocket.html

>As noted above, hop-by-hop headers including “Upgrade” and “Connection” are not passed from a client to proxied server, therefore in order for the proxied server to know about the client’s intention to switch a protocol to WebSocket, these headers have to be passed explicitly:

