### PR TITLE
New server playbook

### DIFF
--- a/new-server-playbook.yml
+++ b/new-server-playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Setup new server with common defaults and basic hardening
+  hosts: all
+  roles:
+    - harden

--- a/roles/harden/defaults/main.yaml
+++ b/roles/harden/defaults/main.yaml
@@ -1,3 +1,4 @@
 admin_username: admin
 admin_password: "use bcrypt to set this as an encrypted password"
+homedir: "/home/{{ admin_username }}"
 admin_ssh_pubkey: /Home/coolperson/.ssh/id_ed25519.pub

--- a/roles/harden/tasks/main.yaml
+++ b/roles/harden/tasks/main.yaml
@@ -21,12 +21,28 @@
     create_home: true
 
 
-- name: Set authorized key for remote admin
-  ansible.posix.authorized_key:
-    user: "{{ admin_username }}"
-    state: present
-    key: "{{ lookup('file', admin_ssh_pubkey) }}"
-  register: admin_added
+- name: Create .ssh folder for admin user
+  ansible.builtin.file:
+    path: "{{ homedir }}/.ssh/"
+    state: directory
+    mode: "0700"
+    owner: "{{ admin_username }}"
+    group: users
+
+
+- name: Copy authorized keys from root dir to admin dir
+  # The authorized keys in root are added during the creation of the droplet. We want to honor the keys added there.
+  ansible.builtin.command:
+    cmd: "cp /root/.ssh/authorized_keys {{ homedir }}/.ssh/authorized_keys"
+
+
+- name: Ensure authorized_keys owned by admin_user
+  ansible.builtin.file:
+    path: "{{ homedir }}/.ssh/authorized_keys"
+    state: file
+    mode: "0700"
+    owner: "{{ admin_username }}"
+    group: users
 
 
 - name: Disable password login for everyone


### PR DESCRIPTION
This is an example playbook for setting up a server that was just created via the digitalocean droplet.

It includes an adjustment to our hardening role where we copy over the existing authorized keys to our admin's directory, instead of uploading a new one.  I think this is the more correct pattern, as we want to mark which keys should have access in the droplet creation, then have our playbook honour that choice.