### PR TITLE
add new-do droplet

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 callback_whitelist = profile_tasks
+roles_path = ./roles
 
 [ssh_connection]
 pipelining = True

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,109 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1686736559,
-        "narHash": "sha256-YyUSVoOKIDAscTx7IZhF9x3qgZ9dPNF19fKk+4c5irc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ddf4688dc7aeb14e8a3c549cb6aa6337f187a884",
+        "lastModified": 1688380630,
+        "narHash": "sha256-8ilApWVb1mAi4439zS3iFeIT0ODlbrifm/fegWwgHjA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f9238ec3d75cefbb2b42a44948c4e8fb1ae9a205",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-23.05",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677383253,
+        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1689534811,
+        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -21,17 +21,21 @@
           pkgs.devshell.mkShell {
             packages = [
               pkgs.ansible
+              pkgs.tree
             ];
             commands = [
               {
                 name = ''new-role'';
                 help = ''scaffolds new role with given name'';
+                category = ''ansible-tasks'';
                 command =
                   ''
                     ROLESDIR=$(git rev-parse --show-toplevel)/roles/$1
                     mkdir -p $ROLESDIR/{tasks,templates,files,defaults,meta}
                     touch $ROLESDIR/{tasks,templates,defaults,meta}/main.yml
                     echo "# $1" >> $ROLESDIR/README.md
+                    echo "new role created: "
+                    tree $ROLESDIR
                   '';
               }
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
                   ''
                     ROLESDIR=$(git rev-parse --show-toplevel)/roles/$1
                     mkdir -p $ROLESDIR/{tasks,templates,files,defaults,meta}
-                    touch $ROLESDIR/{tasks,templates,defaults,meta}/main.yml
+                    touch $ROLESDIR/{tasks,defaults,meta}/main.yml
                     echo "# $1" >> $ROLESDIR/README.md
                     echo "new role created: "
                     tree $ROLESDIR

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,40 @@
 {
   description = "Flake for running ansible scripts";
-  inputs.nixpkgs.url = "nixpkgs/nixos-23.05";
 
-  outputs = { self, nixpkgs }:
-    let
-      supportedSystems = ["x86_64-linux" "x86_64-darwin"  "aarch64-linux" "aarch64-darwin"];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    devshell.url = "github:numtide/devshell";
+  };
 
+  outputs = { self, nixpkgs, flake-utils, devshell }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            devshell.overlays.default
+          ];
+        };
     in
       {
-        devShells = forAllSystems(system:
-          let pkgs = nixpkgsFor.${system};
-          in
-            {
-              default = pkgs.mkShell {
-                buildInputs = with pkgs; [ ansible ];
-                shellHook = ''
-                echo "Welcome to the ansible-shell!"
-                '';
-              };
-            });
-      };
+        devShells.default =
+          pkgs.devshell.mkShell {
+            packages = [
+              pkgs.ansible
+            ];
+            commands = [
+              {
+                name = ''new-role'';
+                help = ''scaffolds new role with given name'';
+                command =
+                  ''
+                    ROLESDIR=$(git rev-parse --show-toplevel)/roles/$1
+                    mkdir -p $ROLESDIR/{tasks,templates,files,defaults,meta}
+                    touch $ROLESDIR/{tasks,templates,defaults,meta}/main.yml
+                    echo "# $1" >> $ROLESDIR/README.md
+                  '';
+              }
+            ];
+          };
+      });
 }

--- a/playbooks/new-do-droplet.yml
+++ b/playbooks/new-do-droplet.yml
@@ -1,0 +1,24 @@
+---
+- name: provision a new digital ocean droplet
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  vars:
+    admin_username: admin
+    do_oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+    do_droplet_name: testing.ansible.fun
+    do_droplet_size: s-1vcpu-1gb
+    do_droplet_region: SFO3
+    do_droplet_image: ubuntu-22-10-x64
+    do_droplet_project: Nos
+    do_droplet_enable_monitoring: true
+    do_droplet_enable_backups: false
+    do_droplet_tags:
+      - development
+    gh_user_keys_to_add:
+      - cooldracula
+      - zachmandeville
+      - mplorentz
+      - boreq
+  roles:
+    - new-do-droplet

--- a/playbooks/new-do-droplet.yml
+++ b/playbooks/new-do-droplet.yml
@@ -12,7 +12,7 @@
     do_droplet_image: ubuntu-22-10-x64
     do_droplet_project: Nos
     do_droplet_enable_monitoring: true
-    do_droplet_enable_backups: false
+    do_droplet_enable_backups: true
     do_droplet_tags:
       - development
     gh_user_keys_to_add:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Install aptitude using apt
+  become: true
   ansible.builtin.apt:
     name: aptitude
     state: latest
@@ -7,6 +8,7 @@
 
 
 - name: Perform a dist-upgrade.
+  become: true
   ansible.builtin.apt:
     upgrade: dist
     update_cache: yes
@@ -14,11 +16,13 @@
 
 
 - name: Remove dependencies that are no longer required.
+  become: true
   ansible.builtin.apt:
     autoremove: yes
 
 
 - name: "Disable Snapd Service"
+  become: true
   ansible.builtin.service:
     name: snapd
     state: stopped
@@ -26,24 +30,26 @@
 
 
 - name: "Uninstall Snapd"
+  become: true
   ansible.builtin.apt:
     pkg: snapd
     state: absent
 
 
 - name: "Remove Snapd directory"
+  become: true
   ansible.builtin.file:
     path: /root/snap
     state: absent
 
 
 - name: Install common packages
+  become: true
   ansible.builtin.apt:
     pkg:
       - curl
       - vim
       - git
-      - ufw
       - rsync
       - jq
       - tmux
@@ -69,5 +75,6 @@
 
 
 - name: Reboot the server (if required).
+  become: true
   ansible.builtin.reboot:
   when: reboot_required_file.stat.exists == true

--- a/roles/harden/tasks/main.yaml
+++ b/roles/harden/tasks/main.yaml
@@ -1,82 +1,23 @@
 ---
 # tasks for hardening a server before further ansible work
-
-- name: Setup passwordless sudo
-  ansible.builtin.lineinfile:
-    path: /etc/sudoers
-    state: present
-    regex: '^%sudo'
-    line: '%sudo ALL=(ALL) NOPASSWD: ALL'
-    validate: '/usr/sbin/visudo -cf %s'
-
-
-- name: Create a new regular user with sudo privileges
-  ansible.builtin.user:
-    name: "{{ admin_username }}"
-    state: present
-    groups: sudo
-    append: true
-    password: "{{ admin_password }}"
-    shell: "/bin/bash"
-    create_home: true
-
-
-- name: Create .ssh folder for admin user
-  ansible.builtin.file:
-    path: "{{ homedir }}/.ssh/"
-    state: directory
-    mode: "0700"
-    owner: "{{ admin_username }}"
-    group: users
-
-
-- name: Copy authorized keys from root dir to admin dir
-  # The authorized keys in root are added during the creation of the droplet. We want to honor the keys added there.
-  ansible.builtin.command:
-    cmd: "cp /root/.ssh/authorized_keys {{ homedir }}/.ssh/authorized_keys"
-
-
-- name: Ensure authorized_keys owned by admin_user
-  ansible.builtin.file:
-    path: "{{ homedir }}/.ssh/authorized_keys"
-    state: file
-    mode: "0700"
-    owner: "{{ admin_username }}"
-    group: users
-
-
-- name: Disable password login for everyone
-  ansible.builtin.lineinfile:
-    path: /etc/ssh/sshd_config
-    state: present
-    regexp: '^#?PasswordAuthentication'
-    line: 'PasswordAuthentication no'
-    validate: "/usr/sbin/sshd -t -f %s"
-
-
-- name: Disable login for root
-  ansible.builtin.lineinfile:
-    path: /etc/ssh/sshd_config
-    state: present
-    regexp: '^#?PermitRootLogin'
-    line: 'PermitRootLogin no'
-    validate: "/usr/sbin/sshd -t -f %s"
-
-
-- name: Restart sshd
-  ansible.builtin.systemd:
-    name: ssh
-    daemon_reload: true
-    state: restarted
-
-
-- name: UFW - Allow SSH connections
-  community.general.ufw:
-    rule: allow
-    name: OpenSSH
+- name: Install UFW
+  become: true
+  ansible.builtin.apt:
+    pkg: ufw
+    state: latest
+    update_cache: true
+    cache_valid_time: 3600
 
 
 - name: UFW - Enable and deny by default
+  become: true
   community.general.ufw:
     state: enabled
     default: deny
+
+
+- name: UFW - Allow SSH connections
+  become: true
+  community.general.ufw:
+    rule: allow
+    name: OpenSSH

--- a/roles/new-do-droplet/README.md
+++ b/roles/new-do-droplet/README.md
@@ -1,0 +1,46 @@
+# new-do-droplets: Provision a new digital ocean droplet
+
+This uses the digital ocean api to provision a new droplet with the provided variables.
+
+To use this, you will need to be a part of Verse's organisation on
+digitalocean.com, and have a [digital ocean api
+token](https://docs.digitalocean.com/reference/api/create-personal-access-token/).
+
+The role is intended to be run locally, since it's purpose is to create your new
+remote host.
+
+For an example of using this role, with its vars, see
+playbooks/new-do-droplet.yml.
+
+# Our opinionated provisioning
+
+Our provisioned droplet will have some opinionated defaults, that are added
+through a cloud-config file we pass along in the provisioning.
+
+The primary opinion is that you should not log in as root, and only ssh login
+should be allowed.
+
+The other core opinion is to use github as the source of the ssh keys for this
+user. The assumption is that if you are part of the digitalocean org, then you
+are also a member of our github org.
+
+Lastly, we do not store the digital ocean api token as a secret in this repo as
+it is a personal access token. Instead, this role assumes the presence of an env
+var named `DO_API_TOKEN` on your local system and uses its value for the role.
+
+
+## Variables
+
+|                     variable |                                                                 purpose |                                              default |
+|-----------------------------:|------------------------------------------------------------------------:|-----------------------------------------------------:|
+|              do_droplet_size |      ram/storage of droplet (see [do slugs](https://slugs.do-api.dev/)) |                                          s-1vcpu-1gb |
+|            do_droplet_region |          datacenter location (see [do slugs](https://slugs.do-api.dev)) |                                                 SFO3 |
+|             do_droplet_image |                                              iso image and architecture |                                     ubuntu-22-10-x64 |
+| do_droplet_enable_monitoring |                                 whether to enable do's monitoring(free) |                                                 true |
+|    do_droplet_enable_backups |                                whether to enable regular backups (paid) |                                                false |
+|              do_droplet_name |                            often the domain of the service we're making | "{{do_droplet_image + '.' ansible_date_time.date }}" |
+|           do_droplet_project |                                 The digital ocean project: Verse or Nos |                                                Verse |
+|              do_droplet_tags |                                 a list of tags to attach to the droplet |                                                 none |
+|          gh_user_keys_to_add | a list of github usernames for people who should have access to droplet |                                                 none |
+|                 do_api_token |                  your api token. We pull this from env var DO_API_TOKEN |                                                 none |
+|               admin_username |                                             the default user of server. |                                                admin |

--- a/roles/new-do-droplet/defaults/main.yml
+++ b/roles/new-do-droplet/defaults/main.yml
@@ -4,6 +4,6 @@ do_droplet_size: s-1vcpu-1gb
 do_droplet_region: SFO3
 do_droplet_image: ubuntu-22-10-x64
 do_droplet_enable_monitoring: true
-do_droplet_enable_backups: false
+do_droplet_enable_backups: true
 do_droplet_name: "{{do_droplet_image + '.' ansible_date_time.date }}"
 do_droplet_project: Verse

--- a/roles/new-do-droplet/defaults/main.yml
+++ b/roles/new-do-droplet/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+admin_username: admin
+do_droplet_size: s-1vcpu-1gb
+do_droplet_region: SFO3
+do_droplet_image: ubuntu-22-10-x64
+do_droplet_enable_monitoring: true
+do_droplet_enable_backups: false
+do_droplet_name: "{{do_droplet_image + '.' ansible_date_time.date }}"
+do_droplet_project: Verse

--- a/roles/new-do-droplet/tasks/main.yml
+++ b/roles/new-do-droplet/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+- name: Create temporary file to store ssh keys
+  ansible.builtin.tempfile:
+    state: file
+    suffix: temp
+  register: sshkeys_tempfile
+
+
+- name: pull down ssh keys for chosen github users
+  ansible.builtin.shell: curl https://github.com/{{ username }}.keys >> {{ sshkeys_tempfile.path }}
+  loop: "{{ gh_user_keys_to_add }}"
+  loop_control:
+    loop_var: username
+
+
+- name: Set ssh keys as var for use in template
+  ansible.builtin.set_fact:
+    do_ssh_keys: "{{ lookup('ansible.builtin.file', sshkeys_tempfile.path) | split('\n') }}"
+
+
+- name: Create a new Droplet assigned to project
+  community.digitalocean.digital_ocean_droplet:
+    state: present
+    oauth_token: "{{ do_oauth_token }}"
+    name: "{{ do_droplet_name }}"
+    size: "{{ do_droplet_size }}"
+    region: "{{ do_droplet_region }}"
+    image: "{{ do_droplet_image }}"
+    ssh_keys:
+      - 95:d7:14:8e:81:7e:33:83:4a:47:8e:af:50:31:65:bd
+      # this is the fingerprint for zach's ssh public key.
+      # We include this because otherwise digital ocean
+      # overrides our sshd config to allow for password authentication.
+      # We turn off password authentication and the ability to login
+      # as root, anyway, so this will not be used.
+    tags: "{{ do_droplet_tags }}"
+    monitoring: "{{ do_droplet_enable_monitoring }}"
+    backups: "{{ do_droplet_enable_backups }}"
+    wait_timeout: 500
+    user_data: "{{ lookup('template', './cloud-config.yml.tpl') }}"
+    project: "{{ do_droplet_project }}"
+  register: new_do_droplet
+
+
+- name: delete ssh temp file
+  ansible.builtin.file:
+    state: absent
+    path:  "{{ sshkeys_tempfile.path }}"
+  when: sshkeys_tempfile.path is defined
+
+
+- name: Show Droplet info
+  ansible.builtin.debug:
+    msg: "{{ do_info | split('\n') }}"
+  vars:
+    do_info: |
+      Droplet ID is {{ new_do_droplet.data.droplet.id }}
+      First Public IPv4 is {{ (new_do_droplet.data.droplet.networks.v4 | selectattr('type', 'equalto', 'public')).0.ip_address | default('<none>', true) }}
+      First Private IPv4 is {{ (new_do_droplet.data.droplet.networks.v4 | selectattr('type', 'equalto', 'private')).0.ip_address | default('<none>', true) }}

--- a/roles/new-do-droplet/tasks/main.yml
+++ b/roles/new-do-droplet/tasks/main.yml
@@ -6,7 +6,7 @@
   register: sshkeys_tempfile
 
 
-- name: pull down ssh keys for chosen github users
+- name: Pull down ssh keys for chosen github users
   ansible.builtin.shell: curl https://github.com/{{ username }}.keys >> {{ sshkeys_tempfile.path }}
   loop: "{{ gh_user_keys_to_add }}"
   loop_control:
@@ -42,7 +42,7 @@
   register: new_do_droplet
 
 
-- name: delete ssh temp file
+- name: Delete ssh temp file
   ansible.builtin.file:
     state: absent
     path:  "{{ sshkeys_tempfile.path }}"

--- a/roles/new-do-droplet/templates/cloud-config.yml.tpl
+++ b/roles/new-do-droplet/templates/cloud-config.yml.tpl
@@ -1,0 +1,40 @@
+#cloud-config
+users:
+  - name: {{ admin_username }}
+    primary_group: {{ admin_username }}
+    ssh-authorized-keys:
+{% for key in do_ssh_keys %}
+      - {{ key }}
+{% endfor %}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+write_files:
+  - path: /etc/ssh/sshd_config
+    content: |
+         Port 22
+         Protocol 2
+         HostKey /etc/ssh/ssh_host_rsa_key
+         HostKey /etc/ssh/ssh_host_dsa_key
+         HostKey /etc/ssh/ssh_host_ecdsa_key
+         HostKey /etc/ssh/ssh_host_ed25519_key
+         SyslogFacility AUTH
+         LogLevel INFO
+         LoginGraceTime 120
+         PermitRootLogin no
+         PasswordAuthentication no
+         StrictModes yes
+         PubkeyAuthentication yes
+         IgnoreRhosts yes
+         HostbasedAuthentication no
+         PermitEmptyPasswords no
+         ChallengeResponseAuthentication no
+         X11Forwarding yes
+         X11DisplayOffset 10
+         PrintMotd no
+         PrintLastLog yes
+         TCPKeepAlive yes
+         AcceptEnv LANG LC_*
+         Subsystem sftp /usr/lib/openssh/sftp-server
+         UsePAM yes
+         AllowUsers {{ admin_username }}


### PR DESCRIPTION
This PR is in response to ticket https://github.com/planetary-social/infrastructure/issues/66.

This role creates a new digital ocean droplet with a configuration that matches the majority of what we did in the harden role.  This lets us move more of the infra work into documented ansible scripts, and once that server is made, we can run all the tasks required to setup a service on it all within a single playbook (before we had to run common/harden separately first, and then the service role for reasons).

The intent and reasoning behind this role is documented in its README, included in this pr, but in short: it's a simple role that uses digital ocean's api to create the server and DO's cloud init feature to create our admin user, add our keys, and remove root login.  

I add the keys via github, as I assumed anyone who could create a server is part of the planetary-social org and would have their keys easily available there.  This pattern could act as an inspiration for a `add-ssh-keys` role later that would be more idempotent than our current setup. 

Lastly, there are some changes to our flake.nix that just brings in additional developer niceties (e.g. a scaffolding command for creating new roles).