### PR TITLE
Add cadvisor 

### DIFF
--- a/roles/nos-crossposting-service/templates/docker-compose.yml.tpl
+++ b/roles/nos-crossposting-service/templates/docker-compose.yml.tpl
@@ -1,7 +1,7 @@
 ---
 version: '3'
 services:
-  notifications:
+  crossposting:
     image: "{{ crossposting_image }}:{{crossposting_image_tag }}"
     container_name: crossposting
     env_file:
@@ -12,3 +12,14 @@ services:
       - "0.0.0.0:{{ crossposting_listen_address }}:{{ crossposting_listen_address }}"
       - "0.0.0.0:{{ crossposting_metrics_listen_address }}:{{ crossposting_metrics_listen_address }}"
     restart: always
+  cadvisor:
+      image: gcr.io/cadvisor/cadvisor:latest
+      restart: unless-stopped
+      container_name: cadvisor
+      ports:
+      - 8080:8080
+      volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro


### PR DESCRIPTION
adds cadvisor to the docker-compose so we can collect docker container metrics for the crossposting service.