### PR TITLE
Posthog play

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
               pkgs.ansible
               pkgs.netcat
               pkgs.tree
+              pkgs.doctl
             ];
             commands = [
               {

--- a/inventories/posthog/README.md
+++ b/inventories/posthog/README.md
@@ -1,0 +1,13 @@
+# posthog Inventory
+
+Inventory of our servers running the posthog service (https://posthog.com/)
+
+Posthog has their own deployment method, outlined here: 
+https://posthog.com/docs/self-host
+
+It is best to follow their method, as posthog is a complex microservice
+architecture whose exact configuration we don't want to try to recreate.
+
+
+This inventory--and corresponding role and playbook--are mostly intended for
+documentation, to show which posthog script we are running for installation.

--- a/inventories/posthog/inventory.yml
+++ b/inventories/posthog/inventory.yml
@@ -1,0 +1,12 @@
+---
+posthog:
+  vars:
+    admin_username: admin
+    homedir: /home/{{ admin_username }}
+    domain: '{{ inventory_hostname }}'
+    posthog_app_tag: latest
+  hosts:
+    posthog.planetary.tools:
+prod:
+  hosts:
+    posthog.planetary.tools:

--- a/new-server-vars.yml
+++ b/new-server-vars.yml
@@ -155,3 +155,25 @@
 # - dev
 # additional_roles:
 # - nos_social
+
+
+# Posthog example
+#-----------------------------
+# domain: posthog.ansible.fun
+# do_droplet_size: s-4vcpu-8gb   # basic, 4 VCPU's, 8gb ram, $48 per month
+# do_droplet_image: ubuntu-22-04-x64
+# do_droplet_region: NYC3
+# do_droplet_project: Nos
+# do_droplet_tags:
+#   - prod
+# gh_user_keys_to_add:
+#   - cooldracula
+#   - zachmandeville
+#   - mplorentz
+#   - boreq
+# inv:  posthog
+# inv_groups:
+#   - posthog
+#   - prod
+# additional_roles:
+#   - posthog

--- a/playbooks/posthog.yml
+++ b/playbooks/posthog.yml
@@ -1,0 +1,11 @@
+# Posthog playbook
+# This playbook installs Posthog(https://posthog.com) onto an ubuntu server
+# The playbook assumes you're running a hardened server, wher eyou cannot login as root. (thus the ansible_user var)
+
+- name: Install new server with Posthog
+  hosts: posthog
+  vars:
+    ansible_user: admin
+    domain: "{{ inventory_hostname }}"
+  roles:
+    - posthog

--- a/roles/posthog/README.md
+++ b/roles/posthog/README.md
@@ -1,0 +1,4 @@
+# posthog
+
+This role is for deploying posthog following its own methods, which is essentially to download a `deploy-hobby` script and then run it.  
+if posthog is already installed, it will re-install it.

--- a/roles/posthog/defaults/main.yml
+++ b/roles/posthog/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+posthog_app_tag: "latest"

--- a/roles/posthog/meta/main.yml
+++ b/roles/posthog/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common

--- a/roles/posthog/tasks/main.yml
+++ b/roles/posthog/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Ensure posthog dir exists
+  ansible.builtin.file:
+    path: "{{ homedir }}/posthog"
+    state: directory
+    mode: '0755'
+
+
+- name: copy env file to posthog file
+  ansible.builtin.template:
+    src: env.tmpl
+    dest: "{{ homedir }}/posthog/.env"
+
+
+- name: Copy install script
+  become: true
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/deploy-hobby"
+    dest: "{{ homedir }}/posthog/deploy-hobby"
+
+
+- name: Run install script
+  become: true
+  ansible.builtin.shell:
+    cmd: bash deploy-hobby {{ posthog_app_tag }} {{ domain }}
+    chdir: "{{ homedir }}/posthog"

--- a/roles/posthog/templates/env.tmpl
+++ b/roles/posthog/templates/env.tmpl
@@ -1,0 +1,3 @@
+SENTRY_DSN='https://public@sentry.example.com'
+DOMAIN={{ domain }}
+ZOO_AUTOPURGE_PURGEINTERVAL=12


### PR DESCRIPTION
adds a posthog play to show how we deployed our posthog service.  This is a v. simple playbook/role/inventory as the majority of the work is handled by posthog's own deployment script.

I tested this by deploying posthog.ansible.fun using the playbook (as part of the new-do-droplet play) and then running it again on the same server.  If you run the play multiple times, it will simply run the deploy script, which creates and restarts the docker containers.  This should be safe for running against existing services. _However_, the suggested way to maintain the posthog deployment is to use their upgrade script, which is fiercely interactive and does not play well with ansible.  Which is to say: I think this play is best suited for starting up new instances of posthog, but we should use their scripts outside of ansible for maintaining existing services.