### PR TITLE
crosspost role accounts for historical redirects

### DIFF
--- a/inventories/nos_crossposting_service/inventory.yml
+++ b/inventories/nos_crossposting_service/inventory.yml
@@ -14,8 +14,12 @@ nos_crossposting_service:
     crossposting_image: ghcr.io/planetary-social/nos-crossposting-service
     crossposting_image_tag: latest
   hosts:
-    tweeter.nos.social:
+    connect.nos.social:
+      redirects:
+        - tweeter.nos.social
 prod:
   hosts:
-    tweeter.nos.social:
-  vars: 
+    tweeter.nos.social: 
+  vars:
+dev:
+  hosts:

--- a/roles/nos-crossposting-service/tasks/main.yml
+++ b/roles/nos-crossposting-service/tasks/main.yml
@@ -17,6 +17,36 @@
     state: link
 
 
+- name: Remove default config from sites-enabled
+  become: true
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
+
+- name: Archive existing configs that are now redirects
+  become: true
+  ansible.builtin.command: mv /etc/nginx/sites-available/{{ redirect }} /etc/nginx/sites-available/{{ redirect }}.bk
+  args:
+    removes: /etc/nginx/sites-available/{{ redirect }}
+    creates: /etc/nginx/sites-available/{{ redirect }}.bk
+  loop: "{{ redirects }}"
+  loop_control:
+    loop_var: redirect
+  when: redirects is defined
+
+
+- name: Remove redirect configs from sites-enabled
+  become: true
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled/{{ redirect }}
+    state: absent
+  loop: "{{ redirects }}"
+  loop_control:
+    loop_var: redirect
+  when: redirects is defined
+
+
 - name: UFW - Allow http/https connections
   become: true
   community.general.ufw:

--- a/roles/nos-crossposting-service/templates/docker-compose.yml.tpl
+++ b/roles/nos-crossposting-service/templates/docker-compose.yml.tpl
@@ -1,7 +1,7 @@
 ---
 version: '3'
 services:
-  notifications:
+  crossposting:
     image: "{{ crossposting_image }}:{{crossposting_image_tag }}"
     container_name: crossposting
     env_file:

--- a/roles/nos-crossposting-service/templates/nginx.conf.tpl
+++ b/roles/nos-crossposting-service/templates/nginx.conf.tpl
@@ -28,6 +28,7 @@ server {
                 include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
                 ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 }
+
 server {
         if ($host = {{ domain }}) {
                 return 301 https://$host$request_uri;
@@ -37,3 +38,20 @@ server {
         listen 80;
         return 404; # managed by Certbot
 }
+
+##
+# Redirects
+##
+{% if redirects is defined %}
+{% for redirect in redirects %}
+server {
+  server_name {{ redirect }};
+  return 301 http://{{ domain }}$request_uri;
+  listen 443 ssl; # managed by Certbot
+          ssl_certificate /etc/letsencrypt/live/{{ redirect }}/fullchain.pem; # managed by Certbot
+          ssl_certificate_key /etc/letsencrypt/live/{{ redirect }}/privkey.pem; # managed by Certbot
+          include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+          ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This pr adjusts our crosspost role to handle domain redirects.  This comes from a situation where our previous domain tweeter.nos.social should now redirect to connect.nos.social. 

My aim in the design is for there to be no state held on the server that is crucial for the playbook to run, while recognizing our inventory files as essentially the state of our servers.  So redirects are specificed in the inventory file, and the role looks to see if redirects are defined and, if so, removes any enabled nginx config.  The nginx template also checks for this var and adds a redirect section to the canonical domain's config. 

I tested this with tweeter.ansible.fun redirecting to connect.ansible.fun and then with tweeter.nos.social redirecting to connectnos.social.  

The role makes two assumptions, in regards to the redirects:
1.) that you have created an A record for the new domain pointing to this server
2.) the previous domains have certs residing on the server.

These feel like fair assumptions. The first is the assumption of any ansible play, and the second is the state the server would be in if you had run the nos-crossposting-service playbook on the server.  If neither assumption is correct, you likely don't need to handle redirects and can just not include that variable in the inventory file.