### PR TITLE
Sentry adjustment: drop deployment, add metrics

### DIFF
--- a/playbooks/node-exporter.yml
+++ b/playbooks/node-exporter.yml
@@ -1,6 +1,7 @@
 - name: install node exporter service on target hosts
   hosts: all
   vars:
+    ansible_user: admin
     node_exporter_version: 1.6.0
     ansible_user: admin
   roles:

--- a/playbooks/sentry.yml
+++ b/playbooks/sentry.yml
@@ -4,23 +4,5 @@
   gather_facts: false
   vars:
     ansible_user: admin
-    admin_username: admin
-    sentry_port: 9000
-  pre_tasks:
-    # SSH Host key checking
-    # https://stackoverflow.com/a/54735937/982195
-    - name: "Check known_hosts for {{ inventory_hostname }}"
-      delegate_to: localhost
-      ansible.builtin.command: shell ssh-keygen -F {{ inventory_hostname }}
-      register: has_entry_in_known_hosts_file
-      failed_when: false
-      changed_when: false
-      ignore_errors: true
-    - name: Ignore host key for on first run for {{ inventory_hostname }}
-      when: has_entry_in_known_hosts_file.rc == 1
-      ansible.builtin.set_fact:
-        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-    - name: Gather Facts
-      ansible.builtin.setup:
   roles:
     - sentry

--- a/roles/node-exporter/files/node-exporter.service
+++ b/roles/node-exporter/files/node-exporter.service
@@ -3,7 +3,7 @@ Description = Node Exporter: prometheus exporter for machine metrics
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/node_exporter
+ExecStart=/usr/local/bin/node_exporter --collector.textfile.directory=/var/lib/node_exporter/textfile_collector
 Restart=always
 
 [Install]

--- a/roles/node-exporter/tasks/main.yml
+++ b/roles/node-exporter/tasks/main.yml
@@ -21,6 +21,14 @@
     state: link
 
 
+- name: Ensure text-collector directory exists
+  become: true
+  ansible.builtin.file:
+    path: "/var/lib/node_exporter/textfile_collector"
+    state: directory
+    mode: '0755'
+
+
 - name: Copy systemd unit file
   ansible.builtin.copy:
     src: node-exporter.service

--- a/roles/sentry/README.md
+++ b/roles/sentry/README.md
@@ -1,13 +1,24 @@
-The Sentry role configures a digital ocean droplet with a running instances of the [Sentry error tracking software](https://sentry.io). Sentry is mainly used to gather crash reports from our iOS app.
+## Sentry Role
 
-## Variables
+We run a self-hosted version of sentry(https://sentry.io), deployed using their
+self hosting instructions:
 
-| variable                   | purpose                                               |
-|----------------------------|-------------------------------------------------------|
-| vault_cloudflare_api_token | Access Cloudflare API for cert renewals               |
-| vault_sentry_secret_key    | Allowing clients to communicate securely with Sentry  |
-| vault_slack_client_id      | Allowing Sentry to post to Slack                      |
-| vault_slack_client_secret  | Allowing Sentry to post to Slack                      |
-| vault_slack_signing_secret | Allowing Sentry to post to Slack                      |
-| vault_google_client_id     | Supporting authentication via Google                  |
-| vault_google_client_secret | Supporting authentication via Google                  |
+https://develop.sentry.dev/self-hosted/
+
+The best way to deploy the service is to follow the instructions in that link,
+since it boils down to downloading and running an install script.  This installation can take a long time (> 30 minutes) and so running it via ansible is not ideal.  While we created a role for this originally, there was too much 
+trickery we had to do to keep our ssh connection open and running while sentry's own script did its job.  We do not want arbitrary ansible issues to interfere with their recommended install path, and so we opted to not use ansible for this.
+
+Following sentry's advice, for our current deployment we have the docker services behind an nginx proxy running on the server, with the TLS handled by the proxy.  The server is also generally hardened 
+
+## Metrics
+
+We do want to keep metrics about the server itself and whether sentry is healthy
+and htis can be handled by ansible. We collect these metrics using
+node-exporter, extending the base exporter with a cusotm check that uses
+sentry's own `/_health` endpoint. So this role now serves to create and add that
+custom extension.
+
+For the curious, you can still check out the tasks section of this role, and the bottom commented out section, to see the steps you'd take to install sentry...but again, these steps should be taken on the server itself, and not via ansible.
+
+

--- a/roles/sentry/meta/main.yml
+++ b/roles/sentry/meta/main.yml
@@ -1,7 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: digital-ocean
-  - role: docker
-  - role: certbot-cloudflare
-  - role: nginx
+  - role: node-exporter

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -1,93 +1,155 @@
 ---
-- name: Clone latest sentry repo
-  ansible.builtin.git:
-    repo: https://github.com/getsentry/self-hosted.git
-    dest: "{{ homedir }}/sentry"
+## This role is not for deploying the sentry service itself, but for setting up
+## a health metric for it.  I want to capture the steps for this in ansible, but
+## this may move to a separate task/role for better clarity.
+##
+## Below the working tasks are commented out tasks for setting up sentry.io.  These should
+## be read as documentation for steps to take, as sentry is best installed outside of ansible
+## using their self-hosting guide.
+##
 
-
-- name: Copy sentry config
-  ansible.builtin.template:
-    src: sentry.config.tpl
-    dest: "{{ homedir }}/sentry/sentry/config.yml"
-    mode: 0644
-
-
-- name: Run sentry install/update script
-  ansible.builtin.command:
-    cmd: ./install.sh --no-report-self-hosted-issues --skip-user-prompt
-    chdir: "{{ homedir }}/sentry"
-  async: 900
-  poll: 10
-
-
-- name: Start services
-  community.docker.docker_compose:
-    project_src: "{{ homedir }}/sentry"
-    build: false
-    restarted: true
-  async: 900
-  poll: 10
-  register: service_started
-  retries: 5
-  until: service_started is success
-
-- ansible.builtin.debug:
-    var: service_started
-
-
-- name: Create first admin user
-  ansible.builtin.command:
-    cmd: docker compose run web createuser --force-update --superuser --email {{ sentry_admin_email }} --password {{ sentry_admin_password }}
-    chdir: "{{ homedir }}/sentry"
-  async: 900
-  poll: 10
-  register: user_created
-  retries: 5
-  until: user_created is success
-
-- ansible.builtin.debug:
-    var: user_created
-
-
-- name: Set nginx config for all services
+# Setup a health metric for our node_exporter textfile_collector, taken from
+# sentry's _health endpoint.
+- name: Copy systemd files for sentry-status-check
   become: true
   ansible.builtin.template:
-    src: nginx.conf.tpl
-    dest: /etc/nginx/sites-available/{{ inventory_hostname }}
-    mode: 0644
+    src: "{{ file.src }}"
+    dest: "{{ file.dest }}"
+    mode: "{{ file.mode }}"
+  loop:
+    - src: sentry-status-check.service.tpl
+      dest: "/etc/systemd/system/sentry-status-check.service"
+      mode: "0644"
+    - src: sentry-status-check.sh.tpl
+      dest: "/usr/local/bin/sentry-status-check.sh"
+      mode: "0755"
+    - src: sentry-status-check.timer.tpl
+      dest: "/etc/systemd/system/sentry-status-check.timer"
+      mode: "0644"
+  loop_control:
+    loop_var: file
 
 
-- name: Symlink site config to sites-enabled
+- name: Enable sentry-status-check service and timer
   become: true
-  ansible.builtin.file:
-    src: "/etc/nginx/sites-available/{{ inventory_hostname }}"
-    dest: "/etc/nginx/sites-enabled/{{ inventory_hostname }}"
-    state: link
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: true
+  loop:
+    - sentry-status-check.service
+    - sentry-status-check.timer
 
 
-- name: UFW - Allow http/https connections
+- name: Start sentry-status-check service
   become: true
-  community.general.ufw:
-    rule: allow
-    name: "Nginx Full"
+  ansible.builtin.systemd:
+    name: sentry-status-check
+    state: started
+    daemon_reload: true
 
 
-- name: UFW - Allow tcp connections for websockets
+- name: Restart node-exporter service
   become: true
-  community.general.ufw:
-    rule: allow
-    port: 80
-    proto: tcp
+  ansible.builtin.systemd:
+    name: sentry-status-check
+    state: started
+    daemon_reload: true
 
 
-- name: Ensure config is valid
-  become: true
-  ansible.builtin.command: nginx -t
-  changed_when: false
+## =====================
+## historical info below
+## =====================
 
 
-- name: Restart nginx
-  become: true
-  ansible.builtin.service:
-    name: nginx
-    state: restarted
+## - name: Clone latest sentry repo
+##   ansible.builtin.git:
+##     repo: https://github.com/getsentry/self-hosted.git
+##     dest: "{{ homedir }}/sentry"
+#
+#
+## - name: Copy sentry config
+##   ansible.builtin.template:
+##     src: sentry.config.tpl
+##     dest: "{{ homedir }}/sentry/sentry/config.yml"
+##     mode: 0644
+#
+#
+## - name: Run sentry install/update script
+##   ansible.builtin.command:
+##     cmd: ./install.sh --no-report-self-hosted-issues --skip-user-prompt
+##     chdir: "{{ homedir }}/sentry"
+##   async: 900
+##   poll: 10
+#
+#
+## - name: Start services
+##   community.docker.docker_compose:
+##     project_src: "{{ homedir }}/sentry"
+##     build: false
+##     restarted: true
+##   async: 900
+##   poll: 10
+##   register: service_started
+##   retries: 5
+##   until: service_started is success
+#
+## - ansible.builtin.debug:
+##     var: service_started
+#
+#
+## - name: Create first admin user
+##   ansible.builtin.command:
+##     cmd: docker compose run web createuser --force-update --superuser --email {{ sentry_admin_email }} --password {{ sentry_admin_password }}
+##     chdir: "{{ homedir }}/sentry"
+##   async: 900
+##   poll: 10
+##   register: user_created
+##   retries: 5
+##   until: user_created is success
+#
+## - ansible.builtin.debug:
+##     var: user_created
+#
+#
+## - name: Set nginx config for all services
+##   become: true
+##   ansible.builtin.template:
+##     src: nginx.conf.tpl
+##     dest: /etc/nginx/sites-available/{{ inventory_hostname }}
+##     mode: 0644
+#
+#
+## - name: Symlink site config to sites-enabled
+##   become: true
+##   ansible.builtin.file:
+##     src: "/etc/nginx/sites-available/{{ inventory_hostname }}"
+##     dest: "/etc/nginx/sites-enabled/{{ inventory_hostname }}"
+##     state: link
+#
+#
+## - name: UFW - Allow http/https connections
+##   become: true
+##   community.general.ufw:
+##     rule: allow
+##     name: "Nginx Full"
+#
+#
+## - name: UFW - Allow tcp connections for websockets
+##   become: true
+##   community.general.ufw:
+##     rule: allow
+##     port: 80
+##     proto: tcp
+#
+#
+## - name: Ensure config is valid
+##   become: true
+##   ansible.builtin.command: nginx -t
+##   changed_when: false
+#
+#
+## - name: Restart nginx
+##   become: true
+##   ansible.builtin.service:
+##     name: nginx
+##     state: restarted

--- a/roles/sentry/templates/sentry-status-check.service.tpl
+++ b/roles/sentry/templates/sentry-status-check.service.tpl
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run sentry-status-check: adds status from {{ inventory_hostname }}/_health to prom metrics
+Wants=sentry-status-check.timer
+
+[Service]
+ExecStart=/usr/local/bin/sentry-status-check.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/sentry/templates/sentry-status-check.sh.tpl
+++ b/roles/sentry/templates/sentry-status-check.sh.tpl
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+http_response=$(curl -s -L -o /dev/null  -w "%{http_code}" http://{{ inventory_hostname }}/_health)
+cat << EOF > /var/lib/node_exporter/textfile_collector/sentry_status_check.prom
+# HELP sentry_status_check http status of pinging {{ inventory_hostname }}/_status.
+# TYPE sentry_status_check gauge
+sentry_status_check $http_response
+EOF

--- a/roles/sentry/templates/sentry-status-check.timer.tpl
+++ b/roles/sentry/templates/sentry-status-check.timer.tpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=Runs sentry-status-check every minute
+Requires=sentry-status-check.service
+
+[Timer]
+Unit=sentry-status-check.service
+OnUnitActiveSec=1m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This PR revises the sentry playbook to comment out the sections around deploying and add in a task for collecting uptime metrics.

For the deployment side, we don't use ansible for deploying sentry since sentry has its own instlal script and the way it is run makes it hard to do with ansible (namely that it takes a long time and it is hard to maintain the ssh connection without timing out).  To reduce the chance for error, and make explicit that we are installing it using sentry's own install method, we comment out the deployment section.  The tasks are still useful as documentation, which is why they are not fully deleted.

For the metric: we want a health check and alert for the sentry service. Luckily, sentry provides that at the endpoint /_health.  This PR adds tasks to extend the node-exporter already on the server to use it's text-collector exporter, which allows for customized metrics to be added.  We then add a shell script that just checks the status code of `/health`.  This lets us set up an alert for if `/health` returns anything other than 200.

