### PR TITLE
Create play for handling SSH keys

### DIFF
--- a/inventories/nos/inventory.yml
+++ b/inventories/nos/inventory.yml
@@ -1,0 +1,24 @@
+---
+nos:
+  hosts:
+    events.nos.social:
+    notifications.nos.social:
+    rss.nos.social:
+    connect.nos.social:
+    events-dev.ansible.fun:
+  vars:
+    # Github users whose keys should be on the server
+    approved_users:
+      - mplorentz
+      - cooldracula
+      - zachmandeville
+      - dcadenas
+    # Github users who should be removed from the server
+    removed_users:
+      - boreq
+dev:
+  hosts:
+    events-dev.ansible.fun:
+prod:
+  hosts:
+    events.nos.social:

--- a/inventories/nos/inventory.yml
+++ b/inventories/nos/inventory.yml
@@ -5,7 +5,11 @@ nos:
     notifications.nos.social:
     rss.nos.social:
     connect.nos.social:
+    relay.nos.social:
     events-dev.ansible.fun:
+    dev-notifications.nos.social:
+    crossposting-dev.ansible.fun:
+    nostrface.ansible.fun:
   vars:
     # Github users whose keys should be on the server
     approved_users:
@@ -19,6 +23,13 @@ nos:
 dev:
   hosts:
     events-dev.ansible.fun:
+    dev-notifications.nos.social:
+    crossposting-dev.ansible.fun:
+    nostrface.ansible.fun:
 prod:
   hosts:
     events.nos.social:
+    notifications.nos.social:
+    rss.nos.social:
+    connect.nos.social:
+    relay.nos.social:

--- a/inventories/posthog/inventory.yml
+++ b/inventories/posthog/inventory.yml
@@ -5,6 +5,13 @@ posthog:
     homedir: /home/{{ admin_username }}
     domain: '{{ inventory_hostname }}'
     posthog_app_tag: latest
+    approved_users:
+      - mplorentz
+      - zachmandeville
+      - cooldracula
+      - rabble
+    removed_users:
+      - boreq
   hosts:
     posthog.planetary.tools:
 prod:

--- a/inventories/pubs/inventory.yml
+++ b/inventories/pubs/inventory.yml
@@ -1,5 +1,13 @@
 ---
 pubs:
+  vars:
+    approved_users:
+      - mplorentz
+      - zachmandeville
+      - cooldracula
+      - rabble
+    removed_users:
+      - boreq
   hosts:
     one.planetary.pub:
     two.planetary.pub:

--- a/inventories/sentry/inventory.yml
+++ b/inventories/sentry/inventory.yml
@@ -10,5 +10,12 @@ sentry:
     sentry_admin_email: ops@nos.social
     sentry_admin_password: '{{ vault_sentry_admin_password }}'
     sentry_port: 9000
+    approved_users:
+      - mplorentz
+      - zachmandeville
+      - cooldracula
+      - rabble
+    removed_users:
+      - boreq
 prod:
   sentry.nos.social:

--- a/new-server-vars.yml
+++ b/new-server-vars.yml
@@ -13,7 +13,7 @@
 #   - cooldracula
 #   - zachmandeville
 #   - mplorentz
-#   - boreq
+#   - dcadenas
 # add_cloudflare_record: true
 # add_cloudflare_wildcard_record: true
 # inv:  nos_event_service
@@ -38,6 +38,7 @@
 #   - cooldracula
 #   - zachmandeville
 #   - mplorentz
+#   - dcadenas
 # inv:  nos_crossposting_service
 # inv_groups:
 #   - nos_crossposting_service
@@ -60,7 +61,7 @@
 #   - cooldracula
 #   - zachmandeville
 #   - mplorentz
-#   - boreq
+#   - dcadenas
 # inv:  notifications_service
 # inv_groups:
 #   - notifications_service
@@ -83,6 +84,7 @@
 #   - cooldracula
 #   - mplorentz
 #   - zachmandeville
+#   - dcadenas
 # inv:  nostrface
 # inv_groups:
 #   - nostrface
@@ -171,7 +173,7 @@
 #   - cooldracula
 #   - zachmandeville
 #   - mplorentz
-#   - boreq
+#   - dcadenas
 # inv:  posthog
 # inv_groups:
 #   - posthog

--- a/playbooks/ssh-keys.yml
+++ b/playbooks/ssh-keys.yml
@@ -4,7 +4,7 @@
 # These should list github usernames whose keys should and should not be on the server, respectively.
 ---
 - name: Remove SSH Keys
-  hosts: nos:&dev
+  hosts: all
   vars:
     ansible_user: admin
   tasks:

--- a/playbooks/ssh-keys.yml
+++ b/playbooks/ssh-keys.yml
@@ -1,0 +1,39 @@
+# Removes the given user's SSH keys from all servers passed in by inventory file
+# Expects two variables, approved_users and removed_users.
+# Both variables are lists, most likely defined in the passed-in inventory file.
+# These should list github usernames whose keys should and should not be on the server, respectively.
+---
+- name: Remove SSH Keys
+  hosts: nos:&dev
+  vars:
+    ansible_user: admin
+  tasks:
+    - name: Check approved_users variable is present
+      ansible.builtin.assert:
+        that:
+          - approved_users is defined
+          - "{{ approved_users | type_debug == 'list' }}"
+        fail_msg: "approved_users not given. Should be a list of github users whose keys should be on the server."
+
+
+    - name: Add approved users' keys to servers
+      ansible.builtin.authorized_key:
+        user: "{{ ansible_user }}"
+        state: present
+        key: "https://github.com/{{ user }}.keys"
+      loop: "{{ approved_users }}"
+      loop_control:
+        loop_var: user
+
+
+    - name: Remove former users' keys from servers
+      ansible.builtin.authorized_key:
+        user: "{{ ansible_user }}"
+        state: absent
+        key: "https://github.com/{{ user }}.keys"
+      loop: "{{ removed_users }}"
+      loop_control:
+        loop_var: user
+      when:
+        - removed_users is defined
+        - removed_users | type_debug == 'list'


### PR DESCRIPTION
This PR brings in `playbooks/ssh-keys.yml` to our ansible scripts.  This play looks for two vars in the given inventory files (or passed in as runtime variables): approved_users and removed_users. 

Both variables are lists of github users.  `approved_users` is required to run the play (it will fail if it doesn't find it, or if it isn't given as a list). `removed_users` is optional.  For each approved user, we ensure their keys (at https://github.com/{{user}}.keys) exists on the remote host, using ansible's builtin `authorized_key` role.

If `removed_users` exists, then we loop through them and ensure their keys are not on the host, using the same builtin.

I deliberated on this, trying to find the most declarative way to set the list of users that should be on a server, while making the play safe and simple to run.  I wanted to use ansible builtins instead of some custom script (e.g. editing or replacing the authorized_keys), to avoid a situation where we could accidentally lock ourselves out of the server due to incorrect string manipulation or what-have-you.    the authorized_key builtin only allows you to add or remove keys, with the option of the `exclusive` attribute to say "add only this key".  That exclusive doesn't work on a loop though, as it just means the last user in the loop would be the only one who could access it.  So I was working on some superuser who gets added exclusively first(e.g. me, so I don't get locked out) and then loop through the list of approved_users and add them.  This had the benefit of not having to keep a second list of removed users, but it was also clanky and dangerous.

So I compromised with the two lists, where you can define them at the inventory level and set different users for different groups of servers.  It still is declarative, and we keep a history of people who formerly had keys but no longer, and is safe.  The downside is we must remember when someone is offboarded and add them to the list.  

I tested this script on our dev servers and then ran it for all pubs and all nos services, removing boreq from the servers and adding dcadenas where relevant.