### PR TITLE
Health check role

### DIFF
--- a/inventories/nos_crossposting_service/inventory.yml
+++ b/inventories/nos_crossposting_service/inventory.yml
@@ -9,6 +9,7 @@ nos_crossposting_service:
     crossposting_metrics_listen_address: 8009
     crossposting_environment: PRODUCTION
     crossposting_log_level: DEBUG
+    crossposting_health_endpoint: "https://{{ inventory_hostname }}"
     crossposting_twitter_key: '{{ vault_crossposting_twitter_key }}'
     crossposting_twitter_key_secret: '{{ vault_crossposting_twitter_key_secret }}'
     crossposting_image: ghcr.io/planetary-social/nos-crossposting-service
@@ -17,9 +18,11 @@ nos_crossposting_service:
     connect.nos.social:
       redirects:
         - tweeter.nos.social
+    crossposting-dev.ansible.fun:
 prod:
   hosts:
     connect.nos.social:
   vars:
 dev:
   hosts:
+    crossposting-dev.ansible.fun:

--- a/inventories/nos_event_service/inventory.yml
+++ b/inventories/nos_event_service/inventory.yml
@@ -9,6 +9,7 @@ nos_event_service:
     events_google_pubsub_credentials_json_path: '{{inventory_dir}}/group_vars/all/vault_pubsub-credentials.json'
     events_listen_address: 8008
     events_environment: PRODUCTION
+    events_health_endpoint: "https://{{ inventory_hostname }}/_health"
     events_pyroscope_server_address: https://pyroscope.nos.pink
     events_pyroscope_basic_auth_user: '{{ vault_events_pyroscope_basic_auth_user }}'
     events_pyroscope_basic_auth_password: '{{ vault_events_pyroscope_basic_auth_password }}'

--- a/inventories/notifications_service/inventory.yml
+++ b/inventories/notifications_service/inventory.yml
@@ -12,6 +12,7 @@ notifications_service:
     domain: '{{ inventory_hostname }}'
     notifications_nostr_listen_address: 8008
     notifications_metrics_listen_address: 8009
+    notifications_health_endpoint: "https://{{inventory_hostname }}/_health"
     notifications_apns_topic: com.verse.Nos
     notifications_apns_certificate: certificate_apns.p12
     notifications_apns_certificate_path: '{{inventory_dir}}/group_vars/all/{{ notifications_apns_certificate}}'

--- a/inventories/rss/inventory.yml
+++ b/inventories/rss/inventory.yml
@@ -2,10 +2,10 @@
 rss:
   hosts:
     rss.nos.social: 
-    rss.ansible.fun:
   vars:
     admin_username: admin
     homedir: /home/{{ admin_username }}
+    rss_health_endpoint: "https://{{ inventory_hostname }}"
     rss_image: cooldracula/rsslay
     rss_image_tag: stable
     rsslay_port: 9018
@@ -15,6 +15,3 @@ rss:
 prod:
   hosts:
     rss.nos.social: 
-dev:
-  hosts:
-    rss.ansible.fun:

--- a/playbooks/rss.yml
+++ b/playbooks/rss.yml
@@ -3,5 +3,5 @@
   vars:
     ansible_user: admin
   roles:
-    - rss
     - node-exporter
+    - rss

--- a/roles/health-check/README.md
+++ b/roles/health-check/README.md
@@ -1,0 +1,15 @@
+# health-check
+
+This role adds a metric to the text file consumed by node exporter, that returns the response of a healthcheck endpoint.
+
+For example: you have a an endpoint at /_health, that returns 200 if things are okay and 500 if not.  This can be used with this healthcheck
+so the node_exporter metrics show whether the server is considered healthy.
+
+The metric will be called `nos_health_check`
+
+There is not an opinion on where the endpoint is, or how it is built, just that it returns an http status code.
+
+## Variables
+
+health_check_endpoint
+

--- a/roles/health-check/defaults/main.yml
+++ b/roles/health-check/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+health_check_endpoint: https://{{ inventory_hostname }}/_health

--- a/roles/health-check/meta/main.yml
+++ b/roles/health-check/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: node-exporter

--- a/roles/health-check/tasks/main.yml
+++ b/roles/health-check/tasks/main.yml
@@ -1,0 +1,47 @@
+# Setup a health metric for our node_exporter textfile_collector, taken from
+# the given health endpoint
+---
+- name: Copy systemd files for nos-health-check
+  become: true
+  ansible.builtin.template:
+    src: "{{ file.src }}"
+    dest: "{{ file.dest }}"
+    mode: "{{ file.mode }}"
+  loop:
+    - src: nos-health-check.service.tpl
+      dest: "/etc/systemd/system/nos-health-check.service"
+      mode: "0644"
+    - src: nos-health-check.sh.tpl
+      dest: "/usr/local/bin/nos-health-check.sh"
+      mode: "0755"
+    - src: nos-health-check.timer.tpl
+      dest: "/etc/systemd/system/nos-health-check.timer"
+      mode: "0644"
+  loop_control:
+    loop_var: file
+
+
+- name: Enable nos-health-check service and timer
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: true
+  loop:
+    - nos-health-check.service
+    - nos-health-check.timer
+
+
+- name: Start nos-health-check service
+  become: true
+  ansible.builtin.systemd:
+    name: nos-health-check
+    state: started
+    daemon_reload: true
+
+
+- name: Restart node-exporter
+  become: true
+  ansible.builtin.systemd:
+    name: node-exporter
+    state: restarted
+    daemon_reload: true

--- a/roles/health-check/templates/nos-health-check.service.tpl
+++ b/roles/health-check/templates/nos-health-check.service.tpl
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run nos-health-check: adds status from {{ health_check_endpoint }}
+Wants=nos-health-check.timer
+
+[Service]
+ExecStart=/usr/local/bin/nos-health-check.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/health-check/templates/nos-health-check.sh.tpl
+++ b/roles/health-check/templates/nos-health-check.sh.tpl
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+http_response=$(curl -s -L -o /dev/null  -w "%{http_code}" {{ health_check_endpoint }})
+cat << EOF > /var/lib/node_exporter/textfile_collector/nos_health_check.prom
+# HELP nos_health_check http status of pinging {{ health_check_endpoint }}
+# TYPE nos_health_check gauge
+nos_health_check $http_response
+EOF

--- a/roles/health-check/templates/nos-health-check.timer.tpl
+++ b/roles/health-check/templates/nos-health-check.timer.tpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=Runs nos-health-check every minute
+Requires=nos-health-check.service
+
+[Timer]
+Unit=nos-health-check.service
+OnUnitActiveSec=1m
+
+[Install]
+WantedBy=timers.target

--- a/roles/nos-crossposting-service/tasks/main.yml
+++ b/roles/nos-crossposting-service/tasks/main.yml
@@ -136,3 +136,10 @@
     service_image_tag: "{{ crossposting_image_tag }}"
     frequency: 3m
     working_dir: "{{ crossposting_dir }}"
+
+
+- name: Setup the health check
+  ansible.builtin.include_role:
+    name: health-check
+  vars:
+    health_endpoint: "{{ crossposting_health_endpoint }}"

--- a/roles/nos-event-service/tasks/main.yml
+++ b/roles/nos-event-service/tasks/main.yml
@@ -55,3 +55,10 @@
     service_image_tag: "{{ events_image_tag }}"
     frequency: 3m
     working_dir: "{{ events_dir }}"
+
+
+- name: Setup the health check
+  ansible.builtin.include_role:
+    name: health-check
+  vars:
+    health_endpoint: "{{ events_health_endpoint }}"

--- a/roles/notifications-service/tasks/main.yml
+++ b/roles/notifications-service/tasks/main.yml
@@ -141,3 +141,10 @@
     service_image_tag: "{{ notifications_image_tag }}"
     frequency: 3m
     working_dir: "{{ notifications_dir }}"
+
+
+- name: Setup the health check
+  ansible.builtin.include_role:
+    name: health-check
+  vars:
+    health_endpoint: "{{ notifications_health_endpoint }}"

--- a/roles/rss/tasks/main.yml
+++ b/roles/rss/tasks/main.yml
@@ -86,3 +86,10 @@
     service_image_tag: "{{ rss_image_tag }}"
     frequency: 3m
     working_dir: "{{ rss_dir }}"
+
+
+- name: Setup the health check
+  ansible.builtin.include_role:
+    name: health-check
+  vars:
+    health_check_endpoint: "{{ rss_health_endpoint }}"


### PR DESCRIPTION
Adds health check role that utilizes the existing node exporter role (and that it is installed as a part of creating new droplets by default) to add a health check to the node exporter metrics.  It expects an endpoint that it can ping regularly to ensure it returns a 200 status.  I then added this role to our relevant nos services.