### PR TITLE
Add dynamic health check command to Health check role

### DIFF
--- a/inventories/relay/inventory.yml
+++ b/inventories/relay/inventory.yml
@@ -1,13 +1,19 @@
 ---
 relay:
   hosts:
-    relay.nos.social:
+    relay.nos.social: 
+    relay-dev.ansible.fun:
   vars:
     admin_username: admin
     homedir: /home/{{ admin_username }}
     cert_email: zach@nos.social
     domain: '{{ inventory_hostname }}'
-    relay_image_tag: '0.9.4'
+    relay_image_tag: 0.9.4
+    relay_health_check_endpoint: "https://{{ domain }}"
+    relay_health_check_command: 'curl -H "Accept: application/nostr+json" -X GET -s -L -o /dev/ -w "%{http_code}" {{ relay_health_check_endpoint }}'
 prod:
   hosts:
-    relay.nos.social:
+    relay.nos.social: 
+dev:
+  hosts:
+    relay-dev.ansible.fun:

--- a/roles/health-check/defaults/main.yml
+++ b/roles/health-check/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 health_check_endpoint: https://{{ inventory_hostname }}/_health
+health_check_command: 'curl -s -L -o /dev/null  -w "%{http_code}" {{ health_check_endpoint }}'

--- a/roles/health-check/templates/nos-health-check.service.tpl
+++ b/roles/health-check/templates/nos-health-check.service.tpl
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run nos-health-check: adds status from {{ health_check_endpoint }}
+Description=Run nos-health-check: adds health metric using output of /usr/local/bin/nos-health-check.sh
 Wants=nos-health-check.timer
 
 [Service]

--- a/roles/health-check/templates/nos-health-check.sh.tpl
+++ b/roles/health-check/templates/nos-health-check.sh.tpl
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-http_response=$(curl -s -L -o /dev/null  -w "%{http_code}" {{ health_check_endpoint }})
+http_response=$({{ health_check_command }})
 cat << EOF > /var/lib/node_exporter/textfile_collector/nos_health_check.prom
 # HELP nos_health_check http status of pinging {{ health_check_endpoint }}
 # TYPE nos_health_check gauge

--- a/roles/nos-crossposting-service/tasks/main.yml
+++ b/roles/nos-crossposting-service/tasks/main.yml
@@ -142,4 +142,4 @@
   ansible.builtin.include_role:
     name: health-check
   vars:
-    health_endpoint: "{{ crossposting_health_endpoint }}"
+    health_check_endpoint: "{{ crossposting_health_endpoint }}"

--- a/roles/relay/tasks/main.yml
+++ b/roles/relay/tasks/main.yml
@@ -16,6 +16,7 @@
     state: directory
     mode: '0755'
 
+
 - name: Ensure strfry directory exists
   become: true
   ansible.builtin.file:
@@ -23,11 +24,13 @@
     state: directory
     mode: '0755'
 
+
 - name: Copy docker-compose.yml to relay dir
   ansible.builtin.template:
     src: docker-compose.yml.tpl
     dest: "{{ homedir }}/services/relay/docker-compose.yml"
     mode: '0644'
+
 
 - name: Copy nginx-redirect.conf to relay dir
   become: true
@@ -36,12 +39,14 @@
     dest: "{{ homedir }}/services/relay/nginx-redirect.conf"
     mode: '0644'
 
+
 - name: Copy strfry.conf to relay dir
   become: true
   ansible.builtin.copy:
     src: "{{ role_path }}/files/strfry.conf"
     dest: "{{ homedir }}/services/relay/strfry.conf"
     mode: '0644'
+
 
 - name: Copy whitelist.js to relay dir
   become: true
@@ -50,10 +55,12 @@
     dest: "{{ homedir }}/services/relay/whitelist.js"
     mode: '0755'
 
+
 - name: ensure docker is running
   ansible.builtin.service:
     name: docker
     state: started
+
 
 - name: Start up docker services
   ansible.builtin.shell: "docker compose down && docker compose up -d"
@@ -62,3 +69,11 @@
   register: service_started
   retries: 5
   until: service_started is success
+
+
+- name: Setup the health check
+  ansible.builtin.include_role:
+    name: health-check
+  vars:
+    health_check_endpoint: "{{ relay_health_check_endpoint }}"
+    health_check_command: "{{ relay_health_check_command }}"


### PR DESCRIPTION
This is a small change that adds a var for the health check command.

Previously it was a curl command that could go to a dynamic health endpoint.  This works in most cases, except when we are trying to ping a relay where the service is only directly connectable through nostr.  A standard curl redirects to webflow and doesn't correctly verify that our relay service is up.

I added a new `health_check_command` var that defaults to the standard curl.  I updated our relay role to use a custom curl command that adds an appropriate nostr header and pings the service directly.  I also did some minor fixes in the role and the crossposting vars that I found during the work.

This was deployed to relay-dev.ansible.fun and then relay.nos.social, which now has a health check that we can monitor via our prometheus/grafana setup.