### PR TITLE
Bump REQs per connection

### DIFF
--- a/roles/relay/files/strfry.conf
+++ b/roles/relay/files/strfry.conf
@@ -56,7 +56,7 @@ relay {
     maxFilterLimit = 500
 
     # Maximum number of subscriptions (concurrent REQs) a connection can have open at any time
-    maxSubsPerConnection = 20
+    maxSubsPerConnection = 100
 
     writePolicy {
         # If non-empty, path to an executable script that implements the writePolicy plugin logic


### PR DESCRIPTION
We are having many too many REQs errors so I'm bumping this config:
```bash
admin@relay:~$ docker logs strfry --follow |& grep 'sending error to' > sample.txt
admin@relay:~$  cat sample.txt | grep -oiE '\]: .*'| sort | uniq -c
      1 ]: bad close: subscription id too short
  11157 ]: bad msg: unparseable message
    124 ]: bad req: arr too big
    172 ]: bad req: filter item too large
     15 ]: bad req: filter item too small
    152 ]: bad req: std::get: wrong index for variant
      2 ]: bad req: total filter items too large
     18 ]: bad req: uneven size input to from_hex
      2 ]: bad req: unexpected character in from_hex: 114
      2 ]: bad req: unexpected character in from_hex: 122
   2912 ]: bad req: unrecognised filter item
   1364 ]: negentropy error: negentropy query missing elements
  20268 ]: too many concurrent REQs
  ```