### PR TITLE
Giftwrap allowed

### DIFF
--- a/roles/nos_social/templates/docker-compose.yml.tpl
+++ b/roles/nos_social/templates/docker-compose.yml.tpl
@@ -20,7 +20,7 @@ services:
      - ./.env
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.nip05api.rule=(Host(`{{ domain }}`) && (PathPrefix(`/metrics`) || PathPrefix(`/api/`) || PathPrefix(`/.well-known`))) && !HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.{{ domain }}`)"
+      - "traefik.http.routers.nip05api.rule=(Host(`{{ domain }}`) && (PathPrefix(`/metrics`) || PathPrefix(`/api/`) || PathPrefix(`/.well-known`)))
       - "traefik.http.routers.nip05api.entrypoints=websecure"
       - "traefik.http.middlewares.nip05api.ratelimit.average={{ nip05api_ratelimit_average }}"
       - "traefik.http.middlewares.nip05api.ratelimit.burst={{ nip05api_ratelimit_burst }}"
@@ -38,8 +38,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.redirect-service.entrypoints=websecure"
-      - "traefik.http.routers.redirect-service.rule=Host(`{{ domain }}`) && !PathPrefix(`/.well-known`)"
-      - "traefik.http.routers.redirect-service.rule=Host(`{{ domain }}`) && !PathPrefix(`/.well-known`) || (HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.{{ domain }}`) && !HostRegexp(`traefik.{{ domain }}`))"
+      - "traefik.http.routers.redirect-service.rule=!PathPrefix(`/api/`) && !PathPrefix(`/.well-known`)
     networks:
       - proxy
 

--- a/roles/relay/files/allowed_rules.js
+++ b/roles/relay/files/allowed_rules.js
@@ -7,6 +7,7 @@ const ALLOWED = {
   eventKinds: [
     0, // Metadata
     3, // Contacts
+    1059, // Gift wrap messages
     10002, // Relay list metadata
   ],
 };

--- a/roles/relay/files/allowed_rules.js
+++ b/roles/relay/files/allowed_rules.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const WHITELIST = {
+const ALLOWED = {
   pubs: {
     add5190be4673768546c18b565da3a699241f0e06a75e2dbc03f18663d1b7b27: true, // Reportinator
   },
@@ -26,10 +26,10 @@ rl.on("line", (line) => {
 
   let res = { id: req.event.id }; // must echo the event's id
 
-  const isWhitelistedPub = WHITELIST.pubs.hasOwnProperty(req.event.pubkey);
-  const isWhitelistedEventKind = WHITELIST.eventKinds.includes(req.event.kind);
+  const isAllowedPub = ALLOWED.pubs.hasOwnProperty(req.event.pubkey);
+  const isAllowedEventKind = ALLOWED.eventKinds.includes(req.event.kind);
 
-  if (isWhitelistedPub || isWhitelistedEventKind) {
+  if (isAllowedPub || isAllowedEventKind) {
     res.action = "accept";
   } else {
     res.action = "reject";

--- a/roles/relay/files/strfry.conf
+++ b/roles/relay/files/strfry.conf
@@ -53,7 +53,7 @@ relay {
 
     writePolicy {
         # If non-empty, path to an executable script that implements the writePolicy plugin logic
-        plugin = "./plugins/whitelist.js"
+        plugin = "./plugins/allowed_rules.js"
 
         # Number of seconds to search backwards for lookback events when starting the writePolicy plugin (0 for no lookback)
         lookbackSeconds = 0

--- a/roles/relay/files/whitelist.js
+++ b/roles/relay/files/whitelist.js
@@ -2,7 +2,7 @@
 
 const WHITELIST = {
   pubs: {
-    add5190be4673768546c18b565da3a699241f0e06a75e2dbc03f18663d1b7b27: true, //Reportinator
+    add5190be4673768546c18b565da3a699241f0e06a75e2dbc03f18663d1b7b27: true, // Reportinator
   },
   eventKinds: [
     0, // Metadata
@@ -11,34 +11,29 @@ const WHITELIST = {
   ],
 };
 
-const rl = require('readline').createInterface({
+const rl = require("readline").createInterface({
   input: process.stdin,
   output: process.stdout,
   terminal: false,
 });
 
-rl.on('line', (line) => {
+rl.on("line", (line) => {
   let req = JSON.parse(line);
 
-  if (req.type === 'lookback') {
-    return; // do nothing
-  }
-
-  if (req.type !== 'new') {
-    console.error('unexpected request type'); // will appear in strfry logs
+  if (req.type === "lookback" || req.type !== "new") {
     return;
   }
 
   let res = { id: req.event.id }; // must echo the event's id
 
-  if (
-    WHITELIST.pubs[req.event.pubkey] ||
-    WHITELIST.eventKinds.includes(req.event.kind)
-  ) {
-    res.action = 'accept';
+  const isWhitelistedPub = WHITELIST.pubs.hasOwnProperty(req.event.pubkey);
+  const isWhitelistedEventKind = WHITELIST.eventKinds.includes(req.event.kind);
+
+  if (isWhitelistedPub || isWhitelistedEventKind) {
+    res.action = "accept";
   } else {
-    res.action = 'reject';
-    res.msg = 'blocked: not on white-list';
+    res.action = "reject";
+    res.msg = "blocked: pubkey not on white-list or event kind not allowed";
   }
 
   console.log(JSON.stringify(res));

--- a/roles/relay/tasks/main.yml
+++ b/roles/relay/tasks/main.yml
@@ -48,11 +48,11 @@
     mode: '0644'
 
 
-- name: Copy whitelist.js to relay dir
+- name: Copy allowed_rules.js to relay dir
   become: true
   ansible.builtin.copy:
-    src: "{{ role_path }}/files/whitelist.js"
-    dest: "{{ homedir }}/services/relay/whitelist.js"
+    src: "{{ role_path }}/files/allowed_rules.js"
+    dest: "{{ homedir }}/services/relay/allowed_rules.js"
     mode: '0755'
 
 

--- a/roles/relay/templates/docker-compose.yml.tpl
+++ b/roles/relay/templates/docker-compose.yml.tpl
@@ -34,7 +34,7 @@ services:
     volumes:
       - ./strfry.conf:/etc/strfry.conf
       - ./strfrydb:/app/strfry-db
-      - ./whitelist.js:/app/plugins/whitelist.js
+      - ./allowed_rules.js:/app/plugins/allowed_rules.js
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.strfry.rule=Host(`{{ domain }}`) && Headers(`Accept`, `application/nostr+json`) || HeadersRegexp(`Connection`, `(?i)Upgrade`) && HeadersRegexp(`Upgrade`, `websocket`)"


### PR DESCRIPTION
Small change to allow kind 1059 so we can communicate to the reportinator server using our own relay as the minimal guaranteed message broker. 

I accidentally included the commits to deal with the subdomain based rules but I think it's not worth to remove them knowing you are leaving soon @cooldracula . Fill free to tackle both things here.