### PR TITLE
Fix webflow redirect

### DIFF
--- a/roles/nos_social/templates/docker-compose.yml.tpl
+++ b/roles/nos_social/templates/docker-compose.yml.tpl
@@ -20,7 +20,7 @@ services:
       - ./.env
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.nip05api.rule=(Host(`{{ domain }}`) && (PathPrefix(`/metrics`) || PathPrefix(`/api/`) || PathPrefix(`/.well-known`)))"
+      - "traefik.http.routers.nip05api.rule=PathPrefix(`/metrics`) || PathPrefix(`/api/`) || PathPrefix(`/.well-known`)"
       - "traefik.http.routers.nip05api.entrypoints=websecure"
       - "traefik.http.middlewares.nip05api.ratelimit.average={{ nip05api_ratelimit_average }}"
       - "traefik.http.middlewares.nip05api.ratelimit.burst={{ nip05api_ratelimit_burst }}"
@@ -38,7 +38,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.redirect-service.entrypoints=websecure"
-      - "traefik.http.routers.redirect-service.rule=!PathPrefix(`/api/`) && !PathPrefix(`/.well-known`)"
+      - "traefik.http.routers.redirect-service.rule=!PathPrefix(`/metrics`) && !PathPrefix(`/api/`) && !PathPrefix(`/.well-known`)"
     networks:
       - proxy
 

--- a/roles/nos_social/templates/nginx-redirect.conf.tpl
+++ b/roles/nos_social/templates/nginx-redirect.conf.tpl
@@ -4,7 +4,7 @@ error_log /dev/stdout;
 access_log /dev/stdout;
 
 upstream webflow {
-    server proxy-ssl.webflow.com:443;
+    server nos-app.webflow.io:443;
 }
 
 server {
@@ -14,7 +14,7 @@ server {
 
     location @webflow {
         proxy_pass                          https://webflow;
-        proxy_set_header Host               $host;
+        proxy_set_header Host nos-app.webflow.io;
         proxy_set_header X-Forwarded-For    $remote_addr;
         proxy_set_header X_FORWARDED_PROTO  https;
         proxy_ssl_verify        off;


### PR DESCRIPTION
The changes that fixed nos.social redirect to webflow are in nginx-redirect.conf.tpl. The other changes in docker-compose are just a cleanup of the rules.

I'm basically using the webflow.io domain format we had at certain point in the past (see commit e94f5ee) but updated to nos-app.webflow.io. I have no idea how that other method through `proxy-ssl.webflow.com` could have worked but maybe it did for some reason? Or the change was never live?