### PR TITLE
Removing old pub servers from inventory

### DIFF
--- a/inventories/oasis/inventory.yml
+++ b/inventories/oasis/inventory.yml
@@ -1,4 +1,4 @@
 ---
 oasis:
   hosts:
-    planetary.rocks:
+    #planetary.rocks: This server has been shut down 6/14/24 https://github.com/planetary-social/infrastructure/issues/117

--- a/inventories/pubs/inventory.yml
+++ b/inventories/pubs/inventory.yml
@@ -11,44 +11,8 @@ pubs:
   hosts:
     one.planetary.pub:
     two.planetary.pub:
-    three.planetary.pub:
-    four.planetary.pub:
-    poetry.planetary.pub:
-    gardening.planetary.pub:
-    fungi.planetary.pub:
-    cooking.planetary.pub:
-    floss.planetary.pub:
-    crypto.planetary.pub:
-    queer.family:
-    espanol.planetary.pub:
-    russian-language.planetary.pub:
-    ukrainian-language.planetary.pub:
-    french-language.planetary.pub:
-    chinese-language.planetary.pub:
 
 system:
   hosts:
     one.planetary.pub:
     two.planetary.pub:
-    three.planetary.pub:
-    four.planetary.pub:
-
-topical:
-  hosts:
-    poetry.planetary.pub:
-    gardening.planetary.pub:
-    fungi.planetary.pub:
-    cooking.planetary.pub:
-    floss.planetary.pub:
-    crypto.planetary.pub:
-    queer.family:
-  vars:
-    hops: 1
-
-language:
-  hosts:
-    espanol.planetary.pub:
-    russian-language.planetary.pub:
-    ukrainian-language.planetary.pub:
-    french-language.planetary.pub:
-    chinese-language.planetary.pub:


### PR DESCRIPTION
https://github.com/planetary-social/infrastructure/issues/117

I also removed the oasis server which was a scuttlebutt client we used to post from the Planetary account. We can fire it back up if we need or we can pop the private key into another SSB app.