### PR TITLE
Add dwebcamp and fixed news tag

### DIFF
--- a/inventories/strfry/inventory.yml
+++ b/inventories/strfry/inventory.yml
@@ -3,8 +3,10 @@ relay:
   hosts:
     relay.nos.social:
       relay_image_tag: latest
+    dwebcamp.nos.social:
+      relay_image_tag: latest
     news.nos.social:
-      relay_image_tag: news_b9903e9
+      relay_image_tag: news
   vars:
     admin_username: admin
     homedir: /home/{{ admin_username }}
@@ -19,3 +21,4 @@ prod:
   hosts:
     relay.nos.social:
     news.nos.social:
+    dwebcamp.nos.social:


### PR DESCRIPTION
Adds dwebcamp.nos.social to the hosts and uses a fixed tag for news.nos.social with no reference to a particular git hash