### PR TITLE
Tweaks for nginx conf

### DIFF
--- a/roles/strfry/templates/nginx-redirect.conf.tpl
+++ b/roles/strfry/templates/nginx-redirect.conf.tpl
@@ -1,4 +1,4 @@
-resolver 8.8.8.8;
+resolver 8.8.8.8 ipv6=off;
 
 error_log /dev/stdout;
 access_log /dev/stdout;
@@ -9,5 +9,12 @@ server {
 
     location ~* ^/(.*) {
         proxy_pass https://nos-relay.webflow.io$request_uri;
+        proxy_ssl_server_name on;
+        proxy_ssl_protocols TLSv1.2 TLSv1.3;
+
+        proxy_set_header Host nos-relay.webflow.io;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
I don't know why this didn't fail before but the relay page was not loading:

```
2024/12/30 14:12:17 [error] 29#29: *5471228 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::ssl/tls alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.18.0.3, server: host.docker.internal, request: "GET / HTTP/1.1", upstream: "https://104.18.36.248:443/", host: "relay.nos.social"
2024/12/30 14:12:17 [error] 29#29: *5471228 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::ssl/tls alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.18.0.3, server: host.docker.internal, request: "GET / HTTP/1.1", upstream: "https://172.64.151.8:443/", host: "relay.nos.social"
2024/12/30 14:12:17 [error] 29#29: *5471228 connect() to [2606:4700:4400::ac40:9708]:443 failed (101: Network unreachable) while connecting to upstream, client: 172.18.0.3, server: host.docker.internal, request: "GET / HTTP/1.1", upstream: "https://[2606:4700:4400::ac40:9708]:443/", host: "relay.nos.social"
2024/12/30 14:12:17 [error] 29#29: *5471228 connect() to [2606:4700:4400::6812:24f8]:443 failed (101: Network unreachable) while connecting to upstream, client: 172.18.0.3, server: host.docker.internal, request: "GET / HTTP/1.1", upstream: "https://[2606:4700:4400::6812:24f8]:443/", host: "relay.nos.social"
172.18.0.3 - - [30/Dec/2024:14:12:17 +0000] "GET / HTTP/1.1" 502 157 "-" "-" "223.178.208.83"
172.18.0.3 - - [30/Dec/2024:14:12:17 +0000] "GET / HTTP/1.1" 502 157 "-" "-"
```

I disabled ip6 and passed SNI and redeployed