### PR TITLE
Fix strfry x-forwarded-for ip by using network_mode: host

### DIFF
--- a/roles/strfry/templates/docker-compose.yml.tpl
+++ b/roles/strfry/templates/docker-compose.yml.tpl
@@ -7,6 +7,7 @@ services:
   traefik:
     image: "traefik:v2.10"
     container_name: "traefik"
+    network_mode: "host" # Let's strfry get the real ip in x-forwarded-for instead of the internal docker ip
     command:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"


### PR DESCRIPTION
While investigating the events service queue, I noticed that events pushed from it were being rejected due to rate limits. The issue occurred because strfry was only seeing Traefik’s internal IP instead of the actual client IP. To resolve this, I added network_mode: "host" to the Traefik service configuration. With this change, strfry now correctly sees the real client IP, and events are no longer rejected.

Caveats:
I acknowledge that using network_mode: "host" is a more open configuration, but given the nature of our relay, which is designed to be highly exposed, this should not introduce significant risks. I also explored alternatives to expose the X-Forwarded-For header without enabling host networking but could not find a suitable solution.