### PR TITLE
Add a playbook that executes the harden role

### DIFF
--- a/playbooks/harden.yml
+++ b/playbooks/harden.yml
@@ -1,0 +1,29 @@
+# Hardens a fresh digital ocean droplet
+# To use: update roles/harden/defaults/main.yml to use the appropriate admin password and your ssh key.
+# ansible-playbook playbooks/harden.yml -i "157.230.2.40,"
+---
+- name: Harden a new server
+  hosts: 'all'
+  gather_facts: false
+  vars:
+    ansible_user: root
+    admin_username: admin
+    # admin_password: ??? how do I set this? htpasswd -bnBC 10 "" password | tr -d ':\n' | sed 's/$2y/$2a/'
+  pre_tasks:
+    # SSH Host key checking
+    # https://stackoverflow.com/a/54735937/982195
+    - name: "Check known_hosts for {{ inventory_hostname }}"
+      delegate_to: localhost
+      ansible.builtin.command: shell ssh-keygen -F {{ inventory_hostname }}
+      register: has_entry_in_known_hosts_file
+      failed_when: false
+      changed_when: false
+      ignore_errors: true
+    - name: Ignore host key for on first run for {{ inventory_hostname }}
+      when: has_entry_in_known_hosts_file.rc == 1
+      ansible.builtin.set_fact:
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+    - name: Gather Facts
+      ansible.builtin.setup:
+  roles:
+    - harden


### PR DESCRIPTION
This is a playbook I wrote a while back to harden a digital ocean droplet without running the `new-do-droplet.yml` playbook.