### PR TITLE
Add config defaults to groups relay

### DIFF
--- a/roles/groups_relay/templates/settings.production.yml.tpl
+++ b/roles/groups_relay/templates/settings.production.yml.tpl
@@ -2,12 +2,12 @@ relay:
   auth_url: "wss://{{ inventory_hostname }}"
   db_path: "/db/data"
 
-# WebSocket settings
-websocket:
-  # Size of the channel for outbound messages (default: 1000)
-  channel_size: 1000
-  # Maximum time a connection can stay open (optional)
-  # Uses humantime format (e.g., "1h", "30m", "24h")
-  max_connection_time: "5m"
-  # Maximum number of concurrent connections (optional)
-  max_connections: 300
+  # WebSocket settings
+  websocket:
+    # Size of the channel for outbound messages (default: 1000)
+    channel_size: 1000
+    # Maximum time a connection can stay open (optional)
+    # Uses humantime format (e.g., "1h", "30m", "24h")
+    max_connection_time: "5m"
+    # Maximum number of concurrent connections (optional)
+    max_connections: 300

--- a/roles/groups_relay/templates/settings.production.yml.tpl
+++ b/roles/groups_relay/templates/settings.production.yml.tpl
@@ -1,3 +1,13 @@
 relay:
   auth_url: "wss://{{ inventory_hostname }}"
   db_path: "/db/data"
+
+# WebSocket settings
+websocket:
+  # Size of the channel for outbound messages (default: 1000)
+  channel_size: 1000
+  # Maximum time a connection can stay open (optional)
+  # Uses humantime format (e.g., "1h", "30m", "24h")
+  max_connection_time: "5m"
+  # Maximum number of concurrent connections (optional)
+  max_connections: 300


### PR DESCRIPTION
I added a new config section to control number of connections and put a limit on the time a connection can be opened.